### PR TITLE
Change to minSDK version from 9 to 16

### DIFF
--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.database"
-        minSdkVersion 9
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Min SDK version 9 caused a minSDK gradle build error when trying to use the FireBaseAuth package