### PR TITLE
Make travis much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,19 @@ android:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
+
+env:
+  - SAMPLE=admob 
+  - SAMPLE=analytics 
+  - SAMPLE=app-indexing 
+  - SAMPLE=auth 
+  - SAMPLE=config 
+  - SAMPLE=crash 
+  - SAMPLE=database 
+  - SAMPLE=dynamiclinks 
+  - SAMPLE=invites 
+  - SAMPLE=messaging 
+  - SAMPLE=storage
+
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ android:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 env:
   - SAMPLE=admob 
   - SAMPLE=analytics 

--- a/build.sh
+++ b/build.sh
@@ -3,43 +3,37 @@
 # Exit on error
 set -e
 
-# List of all samples
-samples=( admob analytics app-indexing auth config crash database dynamiclinks invites messaging storage )
-
 # Limit memory usage
 OPTS='-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 # Work off travis
-if [[ -v TRAVIS_PULL_REQUEST ]]; then
+if [[ ! -z TRAVIS_PULL_REQUEST ]]; then
   echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 else
   echo "TRAVIS_PULL_REQUEST: unset, setting to false"
   TRAVIS_PULL_REQUEST=false
 fi
 
-for sample in "${samples[@]}"
-do
-  echo "Building ${sample}"
+echo "Building ${SAMPLE}"
 
-  # Go to sample directory
-  cd $sample
+# Go to sample directory
+cd $SAMPLE
 
-  # Copy mock google-services file if necessary
-  if [ ! -f ./app/google-services.json ]; then
-    echo "Using mock google-services.json"
-    cp ../mock-google-services.json ./app/google-services.json
-  fi
+# Copy mock google-services file if necessary
+if [ ! -f ./app/google-services.json ]; then
+  echo "Using mock google-services.json"
+  cp ../mock-google-services.json ./app/google-services.json
+fi
 
-  # Build
-  if [ $TRAVIS_PULL_REQUEST = false ] ; then
-    # For a merged commit, build all configurations.
-    GRADLE_OPTS=$OPTS ./gradlew clean build
-  else
-    # On a pull request, just build debug which is much faster and catches
-    # obvious errors.
-    GRADLE_OPTS=$OPTS ./gradlew clean :app:assembleDebug
-  fi
+# Build
+if [ $TRAVIS_PULL_REQUEST = false ] ; then
+  # For a merged commit, build all configurations.
+  GRADLE_OPTS=$OPTS ./gradlew clean build
+else
+  # On a pull request, just build debug which is much faster and catches
+  # obvious errors.
+  GRADLE_OPTS=$OPTS ./gradlew clean :app:assembleDebug
+fi
 
-  # Back to parent directory.
-  cd -
-done
+# Back to parent directory.
+cd -


### PR DESCRIPTION
Two improvements:
  * Build matrix (thanks @iulukaya !)
  * Gradle caching

This gets us down from one big 30-minute build to individual 9-minute builds.

This also opens the door for actually running the tests on Travis!  But I'm not sure if our tests are sufficiently de-flaked for that.