### PR TITLE
changed name to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of quickstart samples demonstrating the Firebase APIs on Android. F
 - [Analytics](analytics)
 - [App-Indexing](app-indexing)
 - [Auth](auth)
-- [Configuration](config)
+- [Config](config)
 - [Crash](crash)
 - [Database](database)
 - [Dynamic Links](dynamiclinks)


### PR DESCRIPTION
since nowhere in the documentation or the samples, Remote-Config is called Configuration, I changed the Readme link to be Config instead of _Configuration_