### PR TITLE
Showcasing the Streaming download API to indicate progress

### DIFF
--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MainActivity.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MainActivity.java
@@ -187,7 +187,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .setAction(MyUploadService.ACTION_UPLOAD));
 
         // Show loading spinner
-        showProgressDialog("Uploading...");
+        showProgressDialog(getString(R.string.progress_uploading));
     }
 
     private void beginDownload() {
@@ -201,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         startService(intent);
 
         // Show loading spinner
-        showProgressDialog("Downloading...");
+        showProgressDialog(getString(R.string.progress_downloading));
     }
 
     private void launchCamera() {
@@ -215,7 +215,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private void signInAnonymously() {
         // Sign in anonymously. Authentication is required to read or write from Firebase Storage.
-        showProgressDialog("Signing in...");
+        showProgressDialog(getString(R.string.progress_auth));
         mAuth.signInAnonymously()
                 .addOnSuccessListener(this, new OnSuccessListener<AuthResult>() {
                     @Override

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MainActivity.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MainActivity.java
@@ -180,14 +180,14 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         updateUI(mAuth.getCurrentUser());
         mDownloadUrl = null;
 
-        // Toast message in case the user does not see the notificatio
-        Toast.makeText(this, "Uploading...", Toast.LENGTH_SHORT).show();
-
         // Start MyUploadService to upload the file, so that the file is uploaded
         // even if this Activity is killed or put in the background
         startService(new Intent(this, MyUploadService.class)
                 .putExtra(MyUploadService.EXTRA_FILE_URI, fileUri)
                 .setAction(MyUploadService.ACTION_UPLOAD));
+
+        // Show loading spinner
+        showProgressDialog("Uploading...");
     }
 
     private void beginDownload() {
@@ -201,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         startService(intent);
 
         // Show loading spinner
-        showProgressDialog();
+        showProgressDialog("Downloading...");
     }
 
     private void launchCamera() {
@@ -215,7 +215,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private void signInAnonymously() {
         // Sign in anonymously. Authentication is required to read or write from Firebase Storage.
-        showProgressDialog();
+        showProgressDialog("Signing in...");
         mAuth.signInAnonymously()
                 .addOnSuccessListener(this, new OnSuccessListener<AuthResult>() {
                     @Override
@@ -273,13 +273,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         ad.show();
     }
 
-    private void showProgressDialog() {
+    private void showProgressDialog(String caption) {
         if (mProgressDialog == null) {
             mProgressDialog = new ProgressDialog(this);
-            mProgressDialog.setMessage("Loading...");
             mProgressDialog.setIndeterminate(true);
         }
 
+        mProgressDialog.setMessage(caption);
         mProgressDialog.show();
     }
 

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
@@ -43,7 +43,7 @@ public abstract class MyBaseTaskService extends Service {
      * Show notification with a progress bar.
      */
     protected void showProgressNotification(String caption, long completedUnits, long totalUnits) {
-        int percentComplete = 50;
+        int percentComplete = 0;
         if (totalUnits > 0) {
             percentComplete = (int) (100 * completedUnits / totalUnits);
         }

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
@@ -1,6 +1,11 @@
 package com.google.firebase.quickstart.firebasestorage;
 
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 /**
@@ -8,6 +13,7 @@ import android.util.Log;
  * count is zero.
  */
 public abstract class MyBaseTaskService extends Service {
+    static final int NOTIFY_ID = 0;
 
     private static final String TAG = "MyBaseTaskService";
     private int mNumTasks = 0;
@@ -31,4 +37,44 @@ public abstract class MyBaseTaskService extends Service {
         }
     }
 
+    /**
+     * Show notification with a progress bar.
+     */
+    protected void showProgressNotification(String caption, int completedUnits, int totalUnits) {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+                .setSmallIcon(R.drawable.ic_file_upload_white_24dp)
+                .setContentTitle(getString(R.string.app_name))
+                .setContentText(caption)
+                .setProgress(totalUnits, completedUnits, false)
+                .setOngoing(true)
+                .setAutoCancel(false);
+
+        NotificationManager manager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        manager.notify(NOTIFY_ID, builder.build());
+    }
+
+    /**
+     * Show notification that the activity finished.
+     */
+    protected void showFinishedNotification(String caption, Intent intent, boolean success) {
+        // Make PendingIntent for notification
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0 /* requestCode */, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        int icon = success ? R.drawable.ic_check_white_24 : R.drawable.ic_error_white_24dp;
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+                .setSmallIcon(icon)
+                .setContentTitle(getString(R.string.app_name))
+                .setContentText(caption)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent);
+
+        NotificationManager manager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        manager.notify(NOTIFY_ID, builder.build());
+    }
 }

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyBaseTaskService.java
@@ -13,7 +13,9 @@ import android.util.Log;
  * count is zero.
  */
 public abstract class MyBaseTaskService extends Service {
-    static final int NOTIFY_ID = 0;
+
+    static final int PROGRESS_NOTIFICATION_ID = 0;
+    static final int FINISHED_NOTIFICATION_ID = 1;
 
     private static final String TAG = "MyBaseTaskService";
     private int mNumTasks = 0;
@@ -40,19 +42,24 @@ public abstract class MyBaseTaskService extends Service {
     /**
      * Show notification with a progress bar.
      */
-    protected void showProgressNotification(String caption, int completedUnits, int totalUnits) {
+    protected void showProgressNotification(String caption, long completedUnits, long totalUnits) {
+        int percentComplete = 50;
+        if (totalUnits > 0) {
+            percentComplete = (int) (100 * completedUnits / totalUnits);
+        }
+
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
                 .setSmallIcon(R.drawable.ic_file_upload_white_24dp)
                 .setContentTitle(getString(R.string.app_name))
                 .setContentText(caption)
-                .setProgress(totalUnits, completedUnits, false)
+                .setProgress(100, percentComplete, false)
                 .setOngoing(true)
                 .setAutoCancel(false);
 
         NotificationManager manager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-        manager.notify(NOTIFY_ID, builder.build());
+        manager.notify(PROGRESS_NOTIFICATION_ID, builder.build());
     }
 
     /**
@@ -75,6 +82,16 @@ public abstract class MyBaseTaskService extends Service {
         NotificationManager manager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-        manager.notify(NOTIFY_ID, builder.build());
+        manager.notify(FINISHED_NOTIFICATION_ID, builder.build());
+    }
+
+    /**
+     * Dismiss the progress notification.
+     */
+    protected void dismissProgressNotification() {
+        NotificationManager manager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        manager.cancel(PROGRESS_NOTIFICATION_ID);
     }
 }

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyDownloadService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyDownloadService.java
@@ -83,7 +83,7 @@ public class MyDownloadService extends MyBaseTaskService {
 
         // Mark task started
         taskStarted();
-        showProgressNotification("Downloading...", 0, 0);
+        showProgressNotification(getString(R.string.progress_downloading), 0, 0);
 
         // Download and get total bytes
         mStorageRef.child(downloadPath).getStream(
@@ -99,7 +99,8 @@ public class MyDownloadService extends MyBaseTaskService {
 
                         while ((size = inputStream.read(buffer)) != -1) {
                             bytesDownloaded += size;
-                            showProgressNotification("Downloading...", (int)bytesDownloaded, (int)totalBytes);
+                            showProgressNotification(getString(R.string.progress_downloading),
+                                    bytesDownloaded, totalBytes);
                         }
 
                         // Close the stream at the end of the Task
@@ -112,8 +113,8 @@ public class MyDownloadService extends MyBaseTaskService {
                         Log.d(TAG, "download:SUCCESS");
 
                         // Send success broadcast with number of bytes downloaded
-                        broadcastDownloadFinished(downloadPath, (int)taskSnapshot.getTotalByteCount());
-                        showDownloadFinishedNotification(downloadPath, (int)taskSnapshot.getTotalByteCount());
+                        broadcastDownloadFinished(downloadPath, taskSnapshot.getTotalByteCount());
+                        showDownloadFinishedNotification(downloadPath, (int) taskSnapshot.getTotalByteCount());
 
                         // Mark task completed
                         taskCompleted();
@@ -138,7 +139,7 @@ public class MyDownloadService extends MyBaseTaskService {
      * Broadcast finished download (success or failure).
      * @return true if a running receiver received the broadcast.
      */
-    private boolean broadcastDownloadFinished(String downloadPath, int bytesDownloaded) {
+    private boolean broadcastDownloadFinished(String downloadPath, long bytesDownloaded) {
         boolean success = bytesDownloaded != -1;
         String action = success ? DOWNLOAD_COMPLETED : DOWNLOAD_ERROR;
 
@@ -153,6 +154,9 @@ public class MyDownloadService extends MyBaseTaskService {
      * Show a notification for a finished download.
      */
     private void showDownloadFinishedNotification(String downloadPath, int bytesDownloaded) {
+        // Hide the progress notification
+        dismissProgressNotification();
+
         // Make Intent to MainActivity
         Intent intent = new Intent(this, MainActivity.class)
                 .putExtra(EXTRA_DOWNLOAD_PATH, downloadPath)
@@ -160,7 +164,7 @@ public class MyDownloadService extends MyBaseTaskService {
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         boolean success = bytesDownloaded != -1;
-        String caption = success ? "Download finished" : "Download failed";
+        String caption = success ? getString(R.string.download_success) : getString(R.string.download_failure);
         showFinishedNotification(caption, intent, true);
     }
 

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyDownloadService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyDownloadService.java
@@ -83,6 +83,7 @@ public class MyDownloadService extends MyBaseTaskService {
 
         // Mark task started
         taskStarted();
+        showProgressNotification("Downloading...", 0, 0);
 
         // Download and get total bytes
         mStorageRef.child(downloadPath).getStream(
@@ -90,6 +91,17 @@ public class MyDownloadService extends MyBaseTaskService {
                     @Override
                     public void doInBackground(StreamDownloadTask.TaskSnapshot taskSnapshot,
                                                InputStream inputStream) throws IOException {
+                        long totalBytes = taskSnapshot.getTotalByteCount();
+                        long bytesDownloaded = 0;
+
+                        byte[] buffer = new byte[1024];
+                        int size;
+
+                        while ((size = inputStream.read(buffer)) != -1) {
+                            bytesDownloaded += size;
+                            showProgressNotification("Downloading...", (int)bytesDownloaded, (int)totalBytes);
+                        }
+
                         // Close the stream at the end of the Task
                         inputStream.close();
                     }
@@ -100,11 +112,8 @@ public class MyDownloadService extends MyBaseTaskService {
                         Log.d(TAG, "download:SUCCESS");
 
                         // Send success broadcast with number of bytes downloaded
-                        Intent broadcast = new Intent(DOWNLOAD_COMPLETED);
-                        broadcast.putExtra(EXTRA_DOWNLOAD_PATH, downloadPath);
-                        broadcast.putExtra(EXTRA_BYTES_DOWNLOADED, taskSnapshot.getTotalByteCount());
-                        LocalBroadcastManager.getInstance(getApplicationContext())
-                                .sendBroadcast(broadcast);
+                        broadcastDownloadFinished(downloadPath, (int)taskSnapshot.getTotalByteCount());
+                        showDownloadFinishedNotification(downloadPath, (int)taskSnapshot.getTotalByteCount());
 
                         // Mark task completed
                         taskCompleted();
@@ -116,16 +125,45 @@ public class MyDownloadService extends MyBaseTaskService {
                         Log.w(TAG, "download:FAILURE", exception);
 
                         // Send failure broadcast
-                        Intent broadcast = new Intent(DOWNLOAD_ERROR);
-                        broadcast.putExtra(EXTRA_DOWNLOAD_PATH, downloadPath);
-                        LocalBroadcastManager.getInstance(getApplicationContext())
-                                .sendBroadcast(broadcast);
+                        broadcastDownloadFinished(downloadPath, -1);
+                        showDownloadFinishedNotification(downloadPath, -1);
 
                         // Mark task completed
                         taskCompleted();
                     }
                 });
     }
+
+    /**
+     * Broadcast finished download (success or failure).
+     * @return true if a running receiver received the broadcast.
+     */
+    private boolean broadcastDownloadFinished(String downloadPath, int bytesDownloaded) {
+        boolean success = bytesDownloaded != -1;
+        String action = success ? DOWNLOAD_COMPLETED : DOWNLOAD_ERROR;
+
+        Intent broadcast = new Intent(action)
+                .putExtra(EXTRA_DOWNLOAD_PATH, downloadPath)
+                .putExtra(EXTRA_BYTES_DOWNLOADED, bytesDownloaded);
+        return LocalBroadcastManager.getInstance(getApplicationContext())
+                .sendBroadcast(broadcast);
+    }
+
+    /**
+     * Show a notification for a finished download.
+     */
+    private void showDownloadFinishedNotification(String downloadPath, int bytesDownloaded) {
+        // Make Intent to MainActivity
+        Intent intent = new Intent(this, MainActivity.class)
+                .putExtra(EXTRA_DOWNLOAD_PATH, downloadPath)
+                .putExtra(EXTRA_BYTES_DOWNLOADED, bytesDownloaded)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        boolean success = bytesDownloaded != -1;
+        String caption = success ? "Download finished" : "Download failed";
+        showFinishedNotification(caption, intent, true);
+    }
+
 
     public static IntentFilter getIntentFilter() {
         IntentFilter filter = new IntentFilter();

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyUploadService.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/MyUploadService.java
@@ -68,7 +68,7 @@ public class MyUploadService extends MyBaseTaskService {
 
         // [START_EXCLUDE]
         taskStarted();
-        showProgressNotification("Uploading...", 0, 0);
+        showProgressNotification(getString(R.string.progress_uploading), 0, 0);
         // [END_EXCLUDE]
 
         // [START get_child_ref]
@@ -83,9 +83,9 @@ public class MyUploadService extends MyBaseTaskService {
                 addOnProgressListener(new OnProgressListener<UploadTask.TaskSnapshot>() {
                     @Override
                     public void onProgress(UploadTask.TaskSnapshot taskSnapshot) {
-                        showProgressNotification("Uploading...",
-                                (int)taskSnapshot.getBytesTransferred(),
-                                (int)taskSnapshot.getTotalByteCount());
+                        showProgressNotification(getString(R.string.progress_uploading),
+                                taskSnapshot.getBytesTransferred(),
+                                taskSnapshot.getTotalByteCount());
                     }
                 })
                 .addOnSuccessListener(new OnSuccessListener<UploadTask.TaskSnapshot>() {
@@ -140,6 +140,9 @@ public class MyUploadService extends MyBaseTaskService {
      * Show a notification for a finished upload.
      */
     private void showUploadFinishedNotification(@Nullable Uri downloadUrl, @Nullable Uri fileUri) {
+        // Hide the progress notification
+        dismissProgressNotification();
+
         // Make Intent to MainActivity
         Intent intent = new Intent(this, MainActivity.class)
                 .putExtra(EXTRA_DOWNLOAD_URL, downloadUrl)
@@ -147,7 +150,7 @@ public class MyUploadService extends MyBaseTaskService {
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         boolean success = downloadUrl != null;
-        String caption = success ? "Upload finished" : "Upload failed";
+        String caption = success ? getString(R.string.upload_success) : getString(R.string.upload_failure);
         showFinishedNotification(caption, intent, success);
     }
 

--- a/storage/app/src/main/res/values/strings.xml
+++ b/storage/app/src/main/res/values/strings.xml
@@ -10,4 +10,14 @@
     <string name="label_download">Download File</string>
     <string name="log_out">Log out</string>
     <string name="success">Success</string>
+
+    <string name="progress_downloading">Downloading…</string>
+    <string name="progress_uploading">Uploading…</string>
+    <string name="progress_auth">Signing In…</string>
+
+    <string name="upload_success">Upload finished</string>
+    <string name="upload_failure">Upload failed</string>\
+
+    <string name="download_success">Download finished</string>
+    <string name="download_failure">Download failure</string>
 </resources>


### PR DESCRIPTION
We don't have an example of how to use the internals of the Streaming API. I added code to the upload and download handlers to exemplify how a developer could use the process data that we provide.