### PR TITLE
fixed metadata name for default notification channel

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -61,7 +61,7 @@ application manifest. In the metadata element specify the ID of the channel that
 be used by default by FCM.
 
     <meta-data
-        android:name="com.google.firebase.messaging.default_notification_channel"
+        android:name="com.google.firebase.messaging.default_notification_channel_id"
         android:value="default_channel_id"/>
 
 Note: You are still required to create a notification channel in code with an ID that

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         <!-- [END fcm_default_icon] -->
         <!-- [START fcm_default_channel] -->
         <meta-data
-            android:name="com.google.firebase.messaging.default_notification_channel"
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="@string/default_notification_channel_id"/>
         <!-- [END fcm_default_channel] -->
         <activity


### PR DESCRIPTION
There is incorrect metadata name for default notification channel. I've posted [stackoverflow question](https://stackoverflow.com/questions/45995337/firebase-messaging-default-notification-channel-doesnt-work) and got answer from Diego Giorgini. So here is fix.