### PR TITLE
Stop using downloadURL property from Task Snapshot

### DIFF
--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation 'com.android.support:support-v4:27.1.0'
 
-    implementation 'com.google.firebase:firebase-auth:12.0.1'
-    implementation 'com.google.firebase:firebase-storage:12.0.1'
+    implementation 'com.google.firebase:firebase-auth:15.0.0'
+    implementation 'com.google.firebase:firebase-storage:15.0.0'
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.1'


### PR DESCRIPTION
The previous method was deprecated in `15.0.0`