### PR TITLE
Change the order of repos used by modules

### DIFF
--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/app-indexing/build.gradle
+++ b/app-indexing/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -14,9 +14,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
         maven { url 'https://maven.fabric.io/public' }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,10 @@ plugins {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
         maven { url 'https://maven.fabric.io/public' }
     }
 

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/crash/build.gradle
+++ b/crash/build.gradle
@@ -16,9 +16,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -16,9 +16,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/dynamiclinks/build.gradle
+++ b/dynamiclinks/build.gradle
@@ -17,9 +17,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -72,16 +72,4 @@ dependencies {
 
 }
 
-configurations {
-    lol
-}
-
-dependencies {
-    lol 'com.google.firebase:firebase-firestore:15.0.0'
-}
-
-task printLocations << {
-    configurations.lol.files.each { println it }
-}
-
 apply plugin: 'com.google.gms.google-services'

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -72,4 +72,16 @@ dependencies {
 
 }
 
+configurations {
+    lol
+}
+
+dependencies {
+    lol 'com.google.firebase:firebase-firestore:15.0.0'
+}
+
+task printLocations << {
+    configurations.lol.files.each { println it }
+}
+
 apply plugin: 'com.google.gms.google-services'

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -17,9 +17,10 @@ buildscript {
 
 allprojects {
     repositories {
+        //mavenLocal() must be listed at the top to facilitate testing
+        mavenLocal()
         jcenter()
         maven { url 'https://maven.google.com' }
-        mavenLocal()
     }
 }
 

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -16,9 +16,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/invites/build.gradle
+++ b/invites/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -18,9 +18,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        maven { url 'https://maven.google.com'  }
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 


### PR DESCRIPTION
Details:
We use the quick start repos to test release candidates by having
these masquerade as artifacts that they serve to demonstrate.
Gradle looks for dependencies through repositories in the order in
which they are listed.
We put mavel local over all other repos to allow artifacts to be
published into mavenLocal and masqeuerade as existing versions
for testing.