### PR TITLE
Close keyboard in Firestore espresso test.

### DIFF
--- a/firestore/app/src/androidTest/java/com/google/firebase/example/fireeats/MainActivityTest.java
+++ b/firestore/app/src/androidTest/java/com/google/firebase/example/fireeats/MainActivityTest.java
@@ -49,14 +49,14 @@ import static org.hamcrest.Matchers.is;
 
     // Input email for account created in the setup.sh
     ViewInteraction emailEditText = onView(withId(R.id.email));
-    emailEditText.perform(click()).perform(replaceText("test@mailinator.com"));
+    emailEditText.perform(click()).perform(replaceText("test@mailinator.com"), closeSoftKeyboard());
     ViewInteraction appCompatButton = onView(withId(R.id.button_next));
     appCompatButton.perform(click());
     Thread.sleep(2000);
 
     //Input password
     ViewInteraction passwordEditText = onView(withId(R.id.password));
-    passwordEditText.perform(replaceText("password"));
+    passwordEditText.perform(replaceText("password"), closeSoftKeyboard());
     ViewInteraction appCompatButton2 = onView(withId(R.id.button_done));
     appCompatButton2.perform(click());
     Thread.sleep(2000);


### PR DESCRIPTION
When running against the default emulator skin, the soft keyboard
overlays the password done button causing test failure. Adding to the
email input view as well as future-proofing.