### PR TITLE
Rewrite Espresso tests with UIAutomator: no sleep!

### DIFF
--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     androidTestImplementation "com.google.firebase:firebase-auth:15.1.0"

--- a/firestore/app/src/androidTest/AndroidManifest.xml
+++ b/firestore/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest package="com.google.firebase.example.fireeats"
+    xmlns:tools="http://schemas.android.com/tools">
+
+  <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+
+</manifest>

--- a/firestore/app/src/main/AndroidManifest.xml
+++ b/firestore/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.firebase.example.fireeats">
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/functions/app/src/androidTest/AndroidManifest.xml
+++ b/functions/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest package="com.google.samples.quickstart.functions"
+    xmlns:tools="http://schemas.android.com/tools">
+
+  <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+
+</manifest>

--- a/functions/app/src/androidTest/java/com/google/samples/quickstart/functions/TestAddNumber.java
+++ b/functions/app/src/androidTest/java/com/google/samples/quickstart/functions/TestAddNumber.java
@@ -3,11 +3,17 @@ package com.google.samples.quickstart.functions;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiSelector;
 import android.test.suitebuilder.annotation.LargeTest;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.replaceText;
@@ -21,6 +27,10 @@ public class TestAddNumber {
   @Rule public ActivityTestRule<MainActivity> mActivityTestRule =
       new ActivityTestRule<>(MainActivity.class);
 
+  @Before public void setUp() {
+    UiDevice.getInstance(getInstrumentation());
+  }
+
   @Test
   public void testAddNumber() {
     ViewInteraction firstNumber = onView(withId(R.id.field_first_number));
@@ -32,16 +42,10 @@ public class TestAddNumber {
     secondNumber.perform(replaceText("16"));
 
     addButton.perform(scrollTo(), click());
-    // Added a sleep statement to match the app's execution delay.
-    // The recommended way to handle such scenarios is to use Espresso idling resources:
-    // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
-    //TODO(samstern) : add a progress indicator to the UI
-    try {
-      Thread.sleep(10000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
 
-    sumResult.check(matches(withText("48")));
+    Assert.assertTrue(
+        new UiObject(new UiSelector()
+          .resourceId("com.google.samples.quickstart.functions:id/field_add_result").text("48"))
+        .waitForExists(60000));
   }
 }


### PR DESCRIPTION
UI tests now run ~twice as fast, while providing more generous individual timeouts.

Also avoids the need to add IdlingResources (or even progress indicators) to the quickstart apps.