### PR TITLE
Extend UIAutomator timeouts.

### DIFF
--- a/firestore/app/src/androidTest/java/com/google/firebase/example/fireeats/MainActivityTest.java
+++ b/firestore/app/src/androidTest/java/com/google/firebase/example/fireeats/MainActivityTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.is;
       new ActivityTestRule<>(MainActivity.class, false, false);
 
   UiDevice device;
-  final long TIMEOUT = 30000;
+  final long TIMEOUT = 300000;  // Five minute timeout because our CI is slooow.
 
   @Before public void before() {
     // Sign out of any existing sessions


### PR DESCRIPTION
We're seeing extreme flakiness with 30s timeouts, so this should do the trick. Hopefully.