### PR TITLE
Missing link with firebase crash

### DIFF
--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
 
     implementation 'com.google.firebase:firebase-core:16.0.0'
+    implementation 'com.google.firebase:firebase-crash:16.0.0'
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.3'
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
I just try to use sample app, and there is missing link dependencies for firebase crash. After I added this dependency, I could see crash report from firebase dashboard.

This is error message that I could receive
com.google.firebase.crash.FirebaseCrash is not linked. Skipping initialization.
