### PR TITLE
Fix linter, increase severity

### DIFF
--- a/internal/lint/src/main/java/com/firebase/lint/InvalidImportDetector.kt
+++ b/internal/lint/src/main/java/com/firebase/lint/InvalidImportDetector.kt
@@ -2,10 +2,9 @@ package com.firebase.lint
 
 import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiJavaFile
-import com.intellij.psi.PsiPackageStatement
 import org.jetbrains.uast.UImportStatement
+
+val SHORT_MESSAGE = "Invalid Import: java package imported from kotlin package."
 
 val ISSUE_INVALID_IMPORT = Issue.create(
         "SuspiciousImport",
@@ -14,7 +13,7 @@ val ISSUE_INVALID_IMPORT = Issue.create(
                 "you have classes with the same name in both `java` and `kotlin` package.",
         Category.CORRECTNESS,
         9,
-        Severity.WARNING,
+        Severity.ERROR,
         Implementation(
                 InvalidImportDetector::class.java,
                 Scope.JAVA_FILE_SCOPE))
@@ -38,17 +37,11 @@ class InvalidImportDetector : Detector(), Detector.UastScanner {
             val classPackageSubFolders = classPackageName.split(".")
             val importedPackageSubFolders = importedPackageName.split(".")
 
-            if (importedPackageName.contains(".java")) {
-                context.report(ISSUE_INVALID_IMPORT, node, context.getLocation(node.importReference!!), "Invalid import")
-
-            }
-
             var i = 0
             while (i < classPackageSubFolders.size && i < importedPackageSubFolders.size) {
-
-                if (classPackageSubFolders[i] == "java" && importedPackageSubFolders[i] == "kotlin") {
+                if (classPackageSubFolders[i] == "kotlin" && importedPackageSubFolders[i] == "java") {
                     node.importReference?.let {
-                        context.report(ISSUE_INVALID_IMPORT, node, context.getLocation(it), "Invalid import")
+                        context.report(ISSUE_INVALID_IMPORT, node, context.getLocation(it), SHORT_MESSAGE)
                     }
                 }
                 i++

--- a/internal/lint/src/test/java/com/firebase/lint/InvalidImportDetectorTest.kt
+++ b/internal/lint/src/test/java/com/firebase/lint/InvalidImportDetectorTest.kt
@@ -42,9 +42,9 @@ class InvalidImportDetectorTest {
                 .issues(ISSUE_INVALID_IMPORT)
                 .run()
                 .expect("""
-          |src/com/google/firebase/kotlin/Example.java:3: Warning: Invalid import [SuspiciousImport]
+          |src/com/google/firebase/kotlin/Example.java:3: Error: $SHORT_MESSAGE [SuspiciousImport]
           |import com.google.firebase.java.Hello;
           |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          |0 errors, 1 warnings""".trimMargin())
+          |1 errors, 0 warnings""".trimMargin())
     }
 }


### PR DESCRIPTION
@the-dagger did a few things here:

  1. We had the linter backwards!  It was looking for `kotlin` imported by `java` not the other way around.
  2. Made it an error.