### PR TITLE
Email link fixes

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -78,6 +78,7 @@ Getting Started
   - Select the **Auth** panel and then click the **Sign In Method** tab.
   - Click **Email/Password** and turn on the **Enable** switch. 
   - Turn on the **Email Link (passwordless sign-in)** switch, then click **Save**.
+- Replace <your-project-id> in the AndroidManifest.xml file with your project ID.
 - Run the app on your device or emulator.
     - Select **PasswordlessActivity** from the main screen.
     - Fill in your desired email and click **Send Link** to begin.

--- a/auth/README.md
+++ b/auth/README.md
@@ -78,7 +78,7 @@ Getting Started
   - Select the **Auth** panel and then click the **Sign In Method** tab.
   - Click **Email/Password** and turn on the **Enable** switch. 
   - Turn on the **Email Link (passwordless sign-in)** switch, then click **Save**.
-- Replace <your-project-id> in the AndroidManifest.xml file with your project ID.
+- Replace your-project-id in the AndroidManifest.xml file with your project ID.
 - Run the app on your device or emulator.
     - Select **PasswordlessActivity** from the main screen.
     - Fill in your desired email and click **Send Link** to begin.

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -40,10 +40,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data
-                    android:host="auth.example.com"
-                    android:pathPrefix="/emailSignInLink"
+                    android:host="<your-project-id>.firebaseapp.com"
                     android:scheme="https" />
-
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
@@ -84,8 +82,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data
-                    android:host="kotlin.auth.example.com"
-                    android:pathPrefix="/emailSignInLink"
+                    android:host="<your-project-id>.firebaseapp.com"
                     android:scheme="https" />
 
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data
-                    android:host="<your-project-id>.firebaseapp.com"
+                    android:host="your-project-id.firebaseapp.com"
                     android:scheme="https" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -82,7 +82,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data
-                    android:host="<your-project-id>.firebaseapp.com"
+                    android:host="your-project-id.firebaseapp.com"
                     android:scheme="https" />
 
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
Looks like we were trying to catch the continueUrl and that doesn't work. We can either catch the dynamic link domain or email action handler url. Also, we can't use pathPrefix to distinguish between links. 

This is for https://github.com/firebase/quickstart-android/issues/488