### PR TITLE
Nullability issues running Kotlin version of Cloud Document Text Recognition

### DIFF
--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/VisionProcessorBase.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/VisionProcessorBase.kt
@@ -101,9 +101,10 @@ abstract class VisionProcessorBase<T> : VisionImageProcessor {
     ) {
         detectInImage(image)
             .addOnSuccessListener { results ->
-                metadata?.let {
-                    onSuccess(originalCameraImage!!, results, it, graphicOverlay)
-                }
+                val notNullOriginalCameraImage = originalCameraImage
+                    ?: Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                val notNullMetadata = metadata ?: FrameMetadata.Builder().build()
+                onSuccess(notNullOriginalCameraImage, results, notNullMetadata, graphicOverlay)
             }
             .addOnFailureListener { e ->
                 this@VisionProcessorBase.onFailure(e)


### PR DESCRIPTION
Running the Kotlin version of Cloud Document Text Recognition loading an image from the file system I spotted this issue:
`detectInVisionImage` of `VisionProcessorBase` is always called with null `originalCameraImage` and null `metadata`
The metadata check for nullability is always failing and is not executing the `onSuccess` even though we don't really need it in the onSuccess body.

The application is ok using the fix proposed, but proably we needed a better refactor to solve it.
