### PR TITLE
[mlkit] Single Camera Handling

### DIFF
--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/common/CameraSource.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/common/CameraSource.java
@@ -129,6 +129,12 @@ public class CameraSource {
     graphicOverlay = overlay;
     graphicOverlay.clear();
     processingRunnable = new FrameProcessingRunnable();
+
+    if (Camera.getNumberOfCameras() == 1) {
+      CameraInfo cameraInfo = new CameraInfo();
+      Camera.getCameraInfo(0, cameraInfo);
+      facing = cameraInfo.facing;
+    }
   }
 
   // ==============================================================================================

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/LivePreviewActivity.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/LivePreviewActivity.java
@@ -16,6 +16,7 @@ package com.google.firebase.samples.apps.mlkit.java;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.hardware.Camera;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
@@ -104,6 +105,10 @@ public final class LivePreviewActivity extends AppCompatActivity
 
     ToggleButton facingSwitch = (ToggleButton) findViewById(R.id.facingSwitch);
     facingSwitch.setOnCheckedChangeListener(this);
+    // Hide the toggle button if there is only 1 camera
+    if (Camera.getNumberOfCameras() == 1) {
+      facingSwitch.setVisibility(View.GONE);
+    }
 
     if (allPermissionsGranted()) {
       createCameraSource(selectedModel);

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/LivePreviewActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/LivePreviewActivity.kt
@@ -87,7 +87,7 @@ class LivePreviewActivity : AppCompatActivity(),
         facingSwitch.setOnCheckedChangeListener(this)
         // Hide switch if there is only a single camera
         if (Camera.getNumberOfCameras() == 1) {
-            facingSwitch.visibility = View.GONE;
+            facingSwitch.visibility = View.GONE
         }
 
         if (allPermissionsGranted()) {

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/LivePreviewActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/LivePreviewActivity.kt
@@ -2,6 +2,7 @@ package com.google.firebase.samples.apps.mlkit.kotlin
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.hardware.Camera
 import android.os.Bundle
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
@@ -84,6 +85,10 @@ class LivePreviewActivity : AppCompatActivity(),
         spinner.onItemSelectedListener = this
 
         facingSwitch.setOnCheckedChangeListener(this)
+        // Hide switch if there is only a single camera
+        if (Camera.getNumberOfCameras() == 1) {
+            facingSwitch.visibility = View.GONE;
+        }
 
         if (allPermissionsGranted()) {
             createCameraSource(selectedModel)


### PR DESCRIPTION
Proposed solution for #748 

*  Detects that there is a single camera on the device and removes the toggle button from the UI when creating the LivePreview activity (both Java and Kotlin)
*  Detects single camera configuration within CameraSource and forces the facing variable to be equal to the value within CameraInfo

Camera enumeration and meta-data require `android.permission.CAMERA`  in the manifest, but do not require the user to approve the `Camera` runtime permission - making the calls used in `onCreate` to determine the toggle button safe to perform prior to validating runtime permissions.