### PR TITLE
Fix proguard rules to work with java/kotlin split.

### DIFF
--- a/firestore/app/proguard-rules.pro
+++ b/firestore/app/proguard-rules.pro
@@ -25,7 +25,8 @@
 #-renamesourcefileattribute SourceFile
 
 # Keep custom model classes
--keep class com.google.firebase.example.fireeats.model.** { *; }
+-keep class com.google.firebase.example.fireeats.java.model.** { *; }
+-keep class com.google.firebase.example.fireeats.kotlin.model.** { *; }
 
 # https://github.com/firebase/FirebaseUI-Android/issues/1175
 -dontwarn okio.**


### PR DESCRIPTION
Without these changes, the app crashes on (approx) startup when in
release mode.