### PR TITLE
Only one messaging service at a time

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -16,6 +16,9 @@ Getting Started
 
 - [Add Firebase to your Android Project](https://firebase.google.com/docs/android/setup).
 - Run the sample on Android device or emulator.
+- There are two `FirebaseMessagingService` defined in `AndroidManifest.xml` to receive
+  incoming messages. Only one of these can be active at any one time so comment one
+  if you would like to guarantee that the other is used.
 
 Sending Notifications
 ---------------------


### PR DESCRIPTION
resolves: #590 

Since only one service can be started at a time, having both kotlin and java services for incoming messages will result in only on being launched. To avoid this uncertainty devs should comment one of the services to ensure that the other (service of interest) is started. 