### PR TITLE
Make FirebaseMessagingServices not exported

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -22,8 +22,8 @@ However, there can only be one service in each app that receives FCM
 messages. If multiple are declared in the Manifest then the first
 one will be chosen.
 
-In order to make the Kotlin messaging sample functional, you must
-remove the following from the `.java.MyFirebaseMessagingService` entry
+In order to make the Java messaging sample functional, you must
+remove the following from the `.kotlin.MyFirebaseMessagingService` entry
 in the `AndroidManifest.xml`:
 
 ```

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -38,14 +38,18 @@
         <activity android:name=".kotlin.MainActivity" />
         <activity android:name=".java.MainActivity" />
 
-        <service android:name=".kotlin.MyFirebaseMessagingService">
+        <service
+            android:name=".kotlin.MyFirebaseMessagingService"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
 
         <!-- [START firebase_service] -->
-        <service android:name=".java.MyFirebaseMessagingService">
+        <service
+            android:name=".java.MyFirebaseMessagingService"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
@@ -34,6 +34,17 @@ import com.google.firebase.quickstart.fcm.R;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 
+/**
+ * NOTE: There can only be one service in each app that receives FCM messages. If multiple
+ * are declared in the Manifest then the first one will be chosen.
+ *
+ * In order to make this Java sample functional, you must remove the following from the Kotlin messaging
+ * service in the AndroidManifest.xml:
+ *
+ * <intent-filter>
+ *   <action android:name="com.google.firebase.MESSAGING_EVENT" />
+ * </intent-filter>
+ */
 public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
     private static final String TAG = "MyFirebaseMsgService";

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
@@ -15,17 +15,6 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.google.firebase.quickstart.fcm.R
 
-/**
- * NOTE: There can only be one service in each app that receives FCM messages. If multiple
- * are declared in the Manifest then the first one will be chosen.
- *
- * In order to make this Kotlin sample functional, you must remove the following from the Java messaging
- * service in the AndroidManifest.xml:
- *
- * <intent-filter>
- *   <action android:name="com.google.firebase.MESSAGING_EVENT" />
- * </intent-filter>
- */
 class MyFirebaseMessagingService : FirebaseMessagingService() {
 
     /**


### PR DESCRIPTION
* Set FirebaseMessagingServices to exported="false" to explicitly
prevent other apps from being able to send messages to it.
* Fixed documentation to indicate to remove the Kotlin service
intent filter for Java now that the Kotlin service is first in the
manifest.