### PR TITLE
Add flag to enable/disable performance monitoring plugin

### DIFF
--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -20,6 +20,14 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            FirebasePerformance {
+                // Set this flag to 'false' to disable @AddTrace annotation processing and
+                // automatic HTTP/S network request monitoring
+                // for a specific build variant at compile time.
+                instrumentationEnabled true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Demonstrate how to enable/disable performance monitoring Gradle plugin for a specific build variant.