### PR TITLE
Blocked on setStickers call

### DIFF
--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
@@ -17,7 +17,7 @@ public class AppIndexingService extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         final Task<Void> setStickersTask = AppIndexingUtil.setStickers(getApplicationContext(), FirebaseAppIndex.getInstance());
-        if (task != null) {
+        if (setStickersTask != null) {
            try {
                Tasks.await(setStickersTask); 
            } catch (ExecutionException e) {

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
@@ -8,6 +8,8 @@ import com.google.android.gms.tasks.Tasks;
 
 import com.google.firebase.appindexing.FirebaseAppIndex;
 
+import java.util.concurrent.ExecutionException;
+
 public class AppIndexingService extends IntentService {
 
     public AppIndexingService() {

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
@@ -3,6 +3,9 @@ package com.google.samples.quickstart.appindexing.java;
 import android.app.IntentService;
 import android.content.Intent;
 
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+
 import com.google.firebase.appindexing.FirebaseAppIndex;
 
 public class AppIndexingService extends IntentService {
@@ -13,6 +16,15 @@ public class AppIndexingService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-        AppIndexingUtil.setStickers(getApplicationContext(), FirebaseAppIndex.getInstance());
+        final Task<Void> setStickersTask = AppIndexingUtil.setStickers(getApplicationContext(), FirebaseAppIndex.getInstance());
+        if (task != null) {
+           try {
+               Tasks.await(setStickersTask); 
+           } catch (ExecutionException e) {
+               // setStickersTask failed 
+           } catch (InterruptedException e) {
+               // this thread was interrupted while waiting for setStickersTask to complete
+           }
+        }
     }
 }

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingUtil.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingUtil.java
@@ -58,7 +58,7 @@ public class AppIndexingUtil {
         });
     }
 
-    public static void setStickers(final Context context, FirebaseAppIndex firebaseAppIndex) {
+    public static Task<Void> setStickers(final Context context, FirebaseAppIndex firebaseAppIndex) {
         try {
             List<Indexable> stickers = getIndexableStickers(context);
             Indexable stickerPack = getIndexableStickerPack(context);
@@ -85,8 +85,11 @@ public class AppIndexingUtil {
                             .show();
                 }
             });
+            
+            return task;
         } catch (IOException | FirebaseAppIndexingInvalidArgumentException e) {
             Log.e(TAG, "Unable to set stickers", e);
+            return null;
         }
     }
 


### PR DESCRIPTION
`AppIndexingService`'s call to `AppIndexingUtil#setStickers` is asynchronous, but `IntentService#onHandleIntent` is a synchronous method, so we must return the `Task<Void>` from `AppIndexingUtil#setStickers` and block `onHandleIntent` until the `setStickers` `Task<Void>` completes.