### PR TITLE
refactor(auth): replace ProgressDialog with ProgressBar

### DIFF
--- a/auth/app/src/androidTest/java/com/google/firebase/quickstart/auth/BaseActivityIdlingResource.java
+++ b/auth/app/src/androidTest/java/com/google/firebase/quickstart/auth/BaseActivityIdlingResource.java
@@ -1,6 +1,8 @@
 package com.google.firebase.quickstart.auth;
 
-import android.app.ProgressDialog;
+import android.view.View;
+import android.widget.ProgressBar;
+
 import androidx.test.espresso.IdlingResource;
 
 import com.google.firebase.quickstart.auth.java.AnonymousAuthActivity;
@@ -8,7 +10,7 @@ import com.google.firebase.quickstart.auth.java.BaseActivity;
 import com.google.firebase.quickstart.auth.java.EmailPasswordActivity;
 
 /**
- * Monitor Activity idle status by watching ProgressDialog.
+ * Monitor Activity idle status by watching ProgressBar.
  */
 public class BaseActivityIdlingResource implements IdlingResource {
 
@@ -30,8 +32,8 @@ public class BaseActivityIdlingResource implements IdlingResource {
 
     @Override
     public boolean isIdleNow() {
-        ProgressDialog dialog = mActivity.mProgressDialog;
-        boolean idle = (dialog == null || !dialog.isShowing());
+        ProgressBar progressBar = mActivity.mProgressBar;
+        boolean idle = (progressBar == null || progressBar.getVisibility() == View.INVISIBLE);
 
         if (mCallback != null && idle) {
             mCallback.onTransitionToIdle();

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
@@ -63,6 +63,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
         // Fields
         mEmailField = findViewById(R.id.fieldEmail);
         mPasswordField = findViewById(R.id.fieldPassword);
+        mProgressBar = findViewById(R.id.progressBar);
 
         // Click listeners
         findViewById(R.id.buttonAnonymousSignIn).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
@@ -63,7 +63,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
         // Fields
         mEmailField = findViewById(R.id.fieldEmail);
         mPasswordField = findViewById(R.id.fieldPassword);
-        mProgressBar = findViewById(R.id.progressBar);
+        setProgressBar(R.id.progressBar);
 
         // Click listeners
         findViewById(R.id.buttonAnonymousSignIn).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
@@ -1,33 +1,27 @@
 package com.google.firebase.quickstart.auth.java;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.ProgressBar;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.firebase.quickstart.auth.R;
-
 public class BaseActivity extends AppCompatActivity {
 
     @VisibleForTesting
-    public ProgressDialog mProgressDialog;
+    public ProgressBar mProgressBar;
 
     public void showProgressDialog() {
-        if (mProgressDialog == null) {
-            mProgressDialog = new ProgressDialog(this);
-            mProgressDialog.setMessage(getString(R.string.loading));
-            mProgressDialog.setIndeterminate(true);
+        if (mProgressBar != null) {
+            mProgressBar.setVisibility(View.VISIBLE);
         }
-
-        mProgressDialog.show();
     }
 
     public void hideProgressDialog() {
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
+        if (mProgressBar != null) {
+            mProgressBar.setVisibility(View.INVISIBLE);
         }
     }
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
@@ -13,6 +13,10 @@ public class BaseActivity extends AppCompatActivity {
     @VisibleForTesting
     public ProgressBar mProgressBar;
 
+    public void setProgressBar(int resId) {
+        mProgressBar = findViewById(resId);
+    }
+
     public void showProgressDialog() {
         if (mProgressBar != null) {
             mProgressBar.setVisibility(View.VISIBLE);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
@@ -57,7 +57,7 @@ public class EmailPasswordActivity extends BaseActivity implements
         mDetailTextView = findViewById(R.id.detail);
         mEmailField = findViewById(R.id.fieldEmail);
         mPasswordField = findViewById(R.id.fieldPassword);
-        mProgressBar = findViewById(R.id.progressBar);
+        setProgressBar(R.id.progressBar);
 
         // Buttons
         findViewById(R.id.emailSignInButton).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
@@ -57,6 +57,7 @@ public class EmailPasswordActivity extends BaseActivity implements
         mDetailTextView = findViewById(R.id.detail);
         mEmailField = findViewById(R.id.fieldEmail);
         mPasswordField = findViewById(R.id.fieldPassword);
+        mProgressBar = findViewById(R.id.progressBar);
 
         // Buttons
         findViewById(R.id.emailSignInButton).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
@@ -66,6 +66,7 @@ public class FacebookLoginActivity extends BaseActivity implements
         // Views
         mStatusTextView = findViewById(R.id.status);
         mDetailTextView = findViewById(R.id.detail);
+        mProgressBar = findViewById(R.id.progressBar);
         findViewById(R.id.buttonFacebookSignout).setOnClickListener(this);
 
         // [START initialize_auth]

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
@@ -66,7 +66,7 @@ public class FacebookLoginActivity extends BaseActivity implements
         // Views
         mStatusTextView = findViewById(R.id.status);
         mDetailTextView = findViewById(R.id.detail);
-        mProgressBar = findViewById(R.id.progressBar);
+        setProgressBar(R.id.progressBar);
         findViewById(R.id.buttonFacebookSignout).setOnClickListener(this);
 
         // [START initialize_auth]

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
@@ -64,7 +64,7 @@ public class GoogleSignInActivity extends BaseActivity implements
         // Views
         mStatusTextView = findViewById(R.id.status);
         mDetailTextView = findViewById(R.id.detail);
-        mProgressBar = findViewById(R.id.progressBar);
+        setProgressBar(R.id.progressBar);
 
         // Button listeners
         findViewById(R.id.signInButton).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
@@ -64,6 +64,7 @@ public class GoogleSignInActivity extends BaseActivity implements
         // Views
         mStatusTextView = findViewById(R.id.status);
         mDetailTextView = findViewById(R.id.detail);
+        mProgressBar = findViewById(R.id.progressBar);
 
         // Button listeners
         findViewById(R.id.signInButton).setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
@@ -59,7 +59,7 @@ public class PasswordlessActivity extends BaseActivity implements View.OnClickLi
         mEmailField = findViewById(R.id.fieldEmail);
         mStatusText = findViewById(R.id.status);
 
-        mProgressBar = findViewById(R.id.progressBar);
+        setProgressBar(R.id.progressBar);
 
         mSendLinkButton.setOnClickListener(this);
         mSignInButton.setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
@@ -59,6 +59,8 @@ public class PasswordlessActivity extends BaseActivity implements View.OnClickLi
         mEmailField = findViewById(R.id.fieldEmail);
         mStatusText = findViewById(R.id.status);
 
+        mProgressBar = findViewById(R.id.progressBar);
+
         mSendLinkButton.setOnClickListener(this);
         mSignInButton.setOnClickListener(this);
         mSignOutButton.setOnClickListener(this);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
@@ -30,6 +30,8 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_anonymous_auth)
 
+        progressBar = findViewById(R.id.progressBar)
+
         // [START initialize_auth]
         // Initialize Firebase Auth
         auth = FirebaseAuth.getInstance()

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
@@ -30,7 +30,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_anonymous_auth)
 
-        progressBar = findViewById(R.id.progressBar)
+        setProgressBar(R.id.progressBar)
 
         // [START initialize_auth]
         // Initialize Firebase Auth

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
@@ -1,30 +1,21 @@
 package com.google.firebase.quickstart.auth.kotlin
 
-import android.app.ProgressDialog
 import android.content.Context
-import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import com.google.firebase.quickstart.auth.R
+import android.widget.ProgressBar
+import androidx.appcompat.app.AppCompatActivity
 
 open class BaseActivity : AppCompatActivity() {
 
-    @VisibleForTesting
-    val progressDialog by lazy {
-        ProgressDialog(this)
-    }
+    var progressBar: ProgressBar? = null
 
     fun showProgressDialog() {
-        progressDialog.setMessage(getString(R.string.loading))
-        progressDialog.isIndeterminate = true
-        progressDialog.show()
+        progressBar?.visibility = View.VISIBLE
     }
 
     fun hideProgressDialog() {
-        if (progressDialog.isShowing) {
-            progressDialog.dismiss()
-        }
+        progressBar?.visibility = View.INVISIBLE
     }
 
     fun hideKeyboard(view: View) {

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
@@ -8,7 +8,11 @@ import androidx.appcompat.app.AppCompatActivity
 
 open class BaseActivity : AppCompatActivity() {
 
-    var progressBar: ProgressBar? = null
+    private var progressBar: ProgressBar? = null
+
+    fun setProgressBar(resId: Int) {
+        progressBar = findViewById(resId)
+    }
 
     fun showProgressDialog() {
         progressBar?.visibility = View.VISIBLE

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
@@ -30,6 +30,8 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_emailpassword)
 
+        progressBar = findViewById(R.id.progressBar)
+
         // Buttons
         emailSignInButton.setOnClickListener(this)
         emailCreateAccountButton.setOnClickListener(this)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
@@ -30,7 +30,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_emailpassword)
 
-        progressBar = findViewById(R.id.progressBar)
+        setProgressBar(R.id.progressBar)
 
         // Buttons
         emailSignInButton.setOnClickListener(this)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
@@ -35,6 +35,8 @@ class FacebookLoginActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_facebook)
 
+        progressBar = findViewById(R.id.progressBar)
+
         buttonFacebookSignout.setOnClickListener(this)
 
         // [START initialize_auth]

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
@@ -35,7 +35,7 @@ class FacebookLoginActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_facebook)
 
-        progressBar = findViewById(R.id.progressBar)
+        setProgressBar(R.id.progressBar)
 
         buttonFacebookSignout.setOnClickListener(this)
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -37,7 +37,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_google)
 
-        progressBar = findViewById(R.id.progressBar)
+        setProgressBar(R.id.progressBar)
 
         // Button listeners
         signInButton.setOnClickListener(this)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -37,6 +37,8 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_google)
 
+        progressBar = findViewById(R.id.progressBar)
+
         // Button listeners
         signInButton.setOnClickListener(this)
         signOutButton.setOnClickListener(this)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
@@ -35,6 +35,8 @@ class PasswordlessActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_passwordless)
 
+        progressBar = findViewById(R.id.progressBar)
+
         // Initialize Firebase Auth
         auth = FirebaseAuth.getInstance()
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
@@ -35,7 +35,7 @@ class PasswordlessActivity : BaseActivity(), View.OnClickListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_passwordless)
 
-        progressBar = findViewById(R.id.progressBar)
+        setProgressBar(R.id.progressBar)
 
         // Initialize Firebase Auth
         auth = FirebaseAuth.getInstance()

--- a/auth/app/src/main/res/layout/activity_anonymous_auth.xml
+++ b/auth/app/src/main/res/layout/activity_anonymous_auth.xml
@@ -9,11 +9,20 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.google.firebase.quickstart.auth.java.AnonymousAuthActivity">
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <ImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
+        android:layout_below="@+id/progressBar"
         android:contentDescription="@string/desc_firebase_lockup"
         android:src="@drawable/firebase_lockup_400" />
 
@@ -101,13 +110,6 @@
         android:enabled="false"
         android:text="Link Account" />
 
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/buttonLinkAccount"
-        android:visibility="invisible"
-        style="?android:attr/progressBarStyleHorizontal"/>
+
 
 </RelativeLayout>

--- a/auth/app/src/main/res/layout/activity_anonymous_auth.xml
+++ b/auth/app/src/main/res/layout/activity_anonymous_auth.xml
@@ -101,4 +101,13 @@
         android:enabled="false"
         android:text="Link Account" />
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/buttonLinkAccount"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
 </RelativeLayout>

--- a/auth/app/src/main/res/layout/activity_emailpassword.xml
+++ b/auth/app/src/main/res/layout/activity_emailpassword.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     android:weightSum="4">
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -41,14 +49,6 @@
             tools:text="Firebase User ID: 123456789abc" />
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_emailpassword.xml
+++ b/auth/app/src/main/res/layout/activity_emailpassword.xml
@@ -42,6 +42,13 @@
 
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_facebook.xml
+++ b/auth/app/src/main/res/layout/activity_facebook.xml
@@ -8,6 +8,14 @@
     android:orientation="vertical"
     android:weightSum="4">
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -42,14 +50,6 @@
             tools:text="Firebase User ID: 123456789abc" />
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_facebook.xml
+++ b/auth/app/src/main/res/layout/activity_facebook.xml
@@ -43,6 +43,14 @@
 
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/auth/app/src/main/res/layout/activity_google.xml
+++ b/auth/app/src/main/res/layout/activity_google.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     android:weightSum="4">
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -41,14 +49,6 @@
             tools:text="Firebase User ID: 123456789abc" />
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_google.xml
+++ b/auth/app/src/main/res/layout/activity_google.xml
@@ -42,6 +42,13 @@
 
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_passwordless.xml
+++ b/auth/app/src/main/res/layout/activity_passwordless.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     android:weightSum="4">
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -41,14 +49,6 @@
             tools:text="Firebase User ID: 123456789abc" />
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/auth/app/src/main/res/layout/activity_passwordless.xml
+++ b/auth/app/src/main/res/layout/activity_passwordless.xml
@@ -42,6 +42,13 @@
 
     </LinearLayout>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        style="?android:attr/progressBarStyleHorizontal"/>
 
     <RelativeLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
[ProgressDialog](https://developer.android.com/reference/android/app/ProgressDialog) has been deprecated in API 26. This PR should replace its usage on the auth quickstart with a ProgressBar.

Here's how it looks now:
![Screenshot from 2019-12-06 13-29-46](https://user-images.githubusercontent.com/16766726/70320453-709aa780-182d-11ea-81e8-106d57c74ad2.png)
![Screenshot from 2019-12-06 13-29-00](https://user-images.githubusercontent.com/16766726/70320454-709aa780-182d-11ea-802a-3bcc0b7b486e.png)

I'll also send follow-up PRs to replace it in:
- [ ] RTDB Quickstart
- [ ] Storage Quickstart