### PR TITLE
refactor(storage): replace ProgressDialog with ProgressBar

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/AnonymousAuthActivity.java
@@ -82,7 +82,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
     // [END on_start_check_user]
 
     private void signInAnonymously() {
-        showProgressDialog();
+        showProgressBar();
         // [START signin_anonymously]
         mAuth.signInAnonymously()
                 .addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
@@ -102,7 +102,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
                         }
 
                         // [START_EXCLUDE]
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -128,7 +128,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
         AuthCredential credential = EmailAuthProvider.getCredential(email, password);
 
         // Link the anonymous user to the email credential
-        showProgressDialog();
+        showProgressBar();
 
         // [START link_credential]
         mAuth.getCurrentUser().linkWithCredential(credential)
@@ -147,7 +147,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
                         }
 
                         // [START_EXCLUDE]
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -177,7 +177,7 @@ public class AnonymousAuthActivity extends BaseActivity implements
     }
 
     private void updateUI(FirebaseUser user) {
-        hideProgressDialog();
+        hideProgressBar();
 
         TextView idView = findViewById(R.id.anonymousStatusId);
         TextView emailView = findViewById(R.id.anonymousStatusEmail);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/BaseActivity.java
@@ -17,13 +17,13 @@ public class BaseActivity extends AppCompatActivity {
         mProgressBar = findViewById(resId);
     }
 
-    public void showProgressDialog() {
+    public void showProgressBar() {
         if (mProgressBar != null) {
             mProgressBar.setVisibility(View.VISIBLE);
         }
     }
 
-    public void hideProgressDialog() {
+    public void hideProgressBar() {
         if (mProgressBar != null) {
             mProgressBar.setVisibility(View.INVISIBLE);
         }
@@ -39,7 +39,7 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     public void onStop() {
         super.onStop();
-        hideProgressDialog();
+        hideProgressBar();
     }
 
 }

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/EmailPasswordActivity.java
@@ -87,7 +87,7 @@ public class EmailPasswordActivity extends BaseActivity implements
             return;
         }
 
-        showProgressDialog();
+        showProgressBar();
 
         // [START create_user_with_email]
         mAuth.createUserWithEmailAndPassword(email, password)
@@ -108,7 +108,7 @@ public class EmailPasswordActivity extends BaseActivity implements
                         }
 
                         // [START_EXCLUDE]
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -121,7 +121,7 @@ public class EmailPasswordActivity extends BaseActivity implements
             return;
         }
 
-        showProgressDialog();
+        showProgressBar();
 
         // [START sign_in_with_email]
         mAuth.signInWithEmailAndPassword(email, password)
@@ -145,7 +145,7 @@ public class EmailPasswordActivity extends BaseActivity implements
                         if (!task.isSuccessful()) {
                             mStatusTextView.setText(R.string.auth_failed);
                         }
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -211,7 +211,7 @@ public class EmailPasswordActivity extends BaseActivity implements
     }
 
     private void updateUI(FirebaseUser user) {
-        hideProgressDialog();
+        hideProgressBar();
         if (user != null) {
             mStatusTextView.setText(getString(R.string.emailpassword_status_fmt,
                     user.getEmail(), user.isEmailVerified()));

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginActivity.java
@@ -129,7 +129,7 @@ public class FacebookLoginActivity extends BaseActivity implements
     private void handleFacebookAccessToken(AccessToken token) {
         Log.d(TAG, "handleFacebookAccessToken:" + token);
         // [START_EXCLUDE silent]
-        showProgressDialog();
+        showProgressBar();
         // [END_EXCLUDE]
 
         AuthCredential credential = FacebookAuthProvider.getCredential(token.getToken());
@@ -151,7 +151,7 @@ public class FacebookLoginActivity extends BaseActivity implements
                         }
 
                         // [START_EXCLUDE]
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -166,7 +166,7 @@ public class FacebookLoginActivity extends BaseActivity implements
     }
 
     private void updateUI(FirebaseUser user) {
-        hideProgressDialog();
+        hideProgressBar();
         if (user != null) {
             mStatusTextView.setText(getString(R.string.facebook_status_fmt, user.getDisplayName()));
             mDetailTextView.setText(getString(R.string.firebase_status_fmt, user.getUid()));

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GenericIdpActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GenericIdpActivity.java
@@ -165,7 +165,7 @@ public class GenericIdpActivity extends BaseActivity implements
     }
 
     private void updateUI(FirebaseUser user) {
-        hideProgressDialog();
+        hideProgressBar();
         if (user != null) {
             mStatusTextView.setText(getString(R.string.generic_status_fmt, user.getDisplayName(), user.getEmail()));
             mDetailTextView.setText(getString(R.string.firebase_status_fmt, user.getUid()));

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
@@ -124,7 +124,7 @@ public class GoogleSignInActivity extends BaseActivity implements
     private void firebaseAuthWithGoogle(GoogleSignInAccount acct) {
         Log.d(TAG, "firebaseAuthWithGoogle:" + acct.getId());
         // [START_EXCLUDE silent]
-        showProgressDialog();
+        showProgressBar();
         // [END_EXCLUDE]
 
         AuthCredential credential = GoogleAuthProvider.getCredential(acct.getIdToken(), null);
@@ -145,7 +145,7 @@ public class GoogleSignInActivity extends BaseActivity implements
                         }
 
                         // [START_EXCLUDE]
-                        hideProgressDialog();
+                        hideProgressBar();
                         // [END_EXCLUDE]
                     }
                 });
@@ -188,7 +188,7 @@ public class GoogleSignInActivity extends BaseActivity implements
     }
 
     private void updateUI(FirebaseUser user) {
-        hideProgressDialog();
+        hideProgressBar();
         if (user != null) {
             mStatusTextView.setText(getString(R.string.google_status_fmt, user.getEmail()));
             mDetailTextView.setText(getString(R.string.firebase_status_fmt, user.getUid()));

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/PasswordlessActivity.java
@@ -140,13 +140,13 @@ public class PasswordlessActivity extends BaseActivity implements View.OnClickLi
                 .build();
 
         hideKeyboard(mEmailField);
-        showProgressDialog();
+        showProgressBar();
 
         mAuth.sendSignInLinkToEmail(email, settings)
                 .addOnCompleteListener(new OnCompleteListener<Void>() {
                     @Override
                     public void onComplete(@NonNull Task<Void> task) {
-                        hideProgressDialog();
+                        hideProgressBar();
 
                         if (task.isSuccessful()) {
                             Log.d(TAG, "Link sent");
@@ -175,13 +175,13 @@ public class PasswordlessActivity extends BaseActivity implements View.OnClickLi
         Log.d(TAG, "signInWithLink:" + link);
 
         hideKeyboard(mEmailField);
-        showProgressDialog();
+        showProgressBar();
 
         mAuth.signInWithEmailLink(email, link)
                 .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
                     @Override
                     public void onComplete(@NonNull Task<AuthResult> task) {
-                        hideProgressDialog();
+                        hideProgressBar();
                         mPendingEmail = null;
 
                         if (task.isSuccessful()) {

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/AnonymousAuthActivity.kt
@@ -53,7 +53,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
     // [END on_start_check_user]
 
     private fun signInAnonymously() {
-        showProgressDialog()
+        showProgressBar()
         // [START signin_anonymously]
         auth.signInAnonymously()
                 .addOnCompleteListener(this) { task ->
@@ -71,7 +71,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
                     }
 
                     // [START_EXCLUDE]
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
         // [END signin_anonymously]
@@ -96,7 +96,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
         val credential = EmailAuthProvider.getCredential(email, password)
 
         // Link the anonymous user to the email credential
-        showProgressDialog()
+        showProgressBar()
 
         // [START link_credential]
         auth.currentUser?.linkWithCredential(credential)
@@ -113,7 +113,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
                     }
 
                     // [START_EXCLUDE]
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
         // [END link_credential]
@@ -142,7 +142,7 @@ class AnonymousAuthActivity : BaseActivity(), View.OnClickListener {
     }
 
     private fun updateUI(user: FirebaseUser?) {
-        hideProgressDialog()
+        hideProgressBar()
         val isSignedIn = user != null
 
         // Status text

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/BaseActivity.kt
@@ -14,11 +14,11 @@ open class BaseActivity : AppCompatActivity() {
         progressBar = findViewById(resId)
     }
 
-    fun showProgressDialog() {
+    fun showProgressBar() {
         progressBar?.visibility = View.VISIBLE
     }
 
-    fun hideProgressDialog() {
+    fun hideProgressBar() {
         progressBar?.visibility = View.INVISIBLE
     }
 
@@ -29,6 +29,6 @@ open class BaseActivity : AppCompatActivity() {
 
     public override fun onStop() {
         super.onStop()
-        hideProgressDialog()
+        hideProgressBar()
     }
 }

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/EmailPasswordActivity.kt
@@ -59,7 +59,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
             return
         }
 
-        showProgressDialog()
+        showProgressBar()
 
         // [START create_user_with_email]
         auth.createUserWithEmailAndPassword(email, password)
@@ -78,7 +78,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
                     }
 
                     // [START_EXCLUDE]
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
         // [END create_user_with_email]
@@ -90,7 +90,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
             return
         }
 
-        showProgressDialog()
+        showProgressBar()
 
         // [START sign_in_with_email]
         auth.signInWithEmailAndPassword(email, password)
@@ -112,7 +112,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
                     if (!task.isSuccessful) {
                         status.setText(R.string.auth_failed)
                     }
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
         // [END sign_in_with_email]
@@ -174,7 +174,7 @@ class EmailPasswordActivity : BaseActivity(), View.OnClickListener {
     }
 
     private fun updateUI(user: FirebaseUser?) {
-        hideProgressDialog()
+        hideProgressBar()
         if (user != null) {
             status.text = getString(R.string.emailpassword_status_fmt,
                     user.email, user.isEmailVerified)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginActivity.kt
@@ -94,7 +94,7 @@ class FacebookLoginActivity : BaseActivity(), View.OnClickListener {
     private fun handleFacebookAccessToken(token: AccessToken) {
         Log.d(TAG, "handleFacebookAccessToken:$token")
         // [START_EXCLUDE silent]
-        showProgressDialog()
+        showProgressBar()
         // [END_EXCLUDE]
 
         val credential = FacebookAuthProvider.getCredential(token.token)
@@ -114,7 +114,7 @@ class FacebookLoginActivity : BaseActivity(), View.OnClickListener {
                     }
 
                     // [START_EXCLUDE]
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
     }
@@ -128,7 +128,7 @@ class FacebookLoginActivity : BaseActivity(), View.OnClickListener {
     }
 
     private fun updateUI(user: FirebaseUser?) {
-        hideProgressDialog()
+        hideProgressBar()
         if (user != null) {
             status.text = getString(R.string.facebook_status_fmt, user.displayName)
             detail.text = getString(R.string.firebase_status_fmt, user.uid)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GenericIdpActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GenericIdpActivity.kt
@@ -118,7 +118,7 @@ class GenericIdpActivity : BaseActivity(), View.OnClickListener {
     }
 
     private fun updateUI(user: FirebaseUser?) {
-        hideProgressDialog()
+        hideProgressBar()
         if (user != null) {
             status.text = getString(R.string.generic_status_fmt, user.displayName, user.email)
             detail.text = getString(R.string.firebase_status_fmt, user.uid)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -95,7 +95,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
     private fun firebaseAuthWithGoogle(acct: GoogleSignInAccount) {
         Log.d(TAG, "firebaseAuthWithGoogle:" + acct.id!!)
         // [START_EXCLUDE silent]
-        showProgressDialog()
+        showProgressBar()
         // [END_EXCLUDE]
 
         val credential = GoogleAuthProvider.getCredential(acct.idToken, null)
@@ -114,7 +114,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
                     }
 
                     // [START_EXCLUDE]
-                    hideProgressDialog()
+                    hideProgressBar()
                     // [END_EXCLUDE]
                 }
     }
@@ -148,7 +148,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
     }
 
     private fun updateUI(user: FirebaseUser?) {
-        hideProgressDialog()
+        hideProgressBar()
         if (user != null) {
             status.text = getString(R.string.google_status_fmt, user.email)
             detail.text = getString(R.string.firebase_status_fmt, user.uid)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/PasswordlessActivity.kt
@@ -115,11 +115,11 @@ class PasswordlessActivity : BaseActivity(), View.OnClickListener {
                 .build()
 
         hideKeyboard(fieldEmail)
-        showProgressDialog()
+        showProgressBar()
 
         auth.sendSignInLinkToEmail(email, settings)
                 .addOnCompleteListener { task ->
-                    hideProgressDialog()
+                    hideProgressBar()
 
                     if (task.isSuccessful) {
                         Log.d(TAG, "Link sent")
@@ -147,11 +147,11 @@ class PasswordlessActivity : BaseActivity(), View.OnClickListener {
         Log.d(TAG, "signInWithLink:" + link!!)
 
         hideKeyboard(fieldEmail)
-        showProgressDialog()
+        showProgressBar()
 
         auth.signInWithEmailLink(email, link)
                 .addOnCompleteListener { task ->
-                    hideProgressDialog()
+                    hideProgressBar()
                     if (task.isSuccessful) {
                         Log.d(TAG, "signInWithEmailLink:success")
 

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/java/MainActivity.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/java/MainActivity.java
@@ -16,7 +16,6 @@
 
 package com.google.firebase.quickstart.firebasestorage.java;
 
-import android.app.ProgressDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -26,6 +25,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -59,7 +59,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private static final String KEY_DOWNLOAD_URL = "key_download_url";
 
     private BroadcastReceiver mBroadcastReceiver;
-    private ProgressDialog mProgressDialog;
+    private ProgressBar mProgressBar;
+    private TextView mCaption;
     private FirebaseAuth mAuth;
 
     private Uri mDownloadUrl = null;
@@ -72,6 +73,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         // Initialize Firebase Auth
         mAuth = FirebaseAuth.getInstance();
+
+        mProgressBar = findViewById(R.id.progressBar);
+        mCaption = findViewById(R.id.caption);
 
         // Click listeners
         findViewById(R.id.buttonCamera).setOnClickListener(this);
@@ -278,19 +282,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     private void showProgressDialog(String caption) {
-        if (mProgressDialog == null) {
-            mProgressDialog = new ProgressDialog(this);
-            mProgressDialog.setIndeterminate(true);
-        }
-
-        mProgressDialog.setMessage(caption);
-        mProgressDialog.show();
+        mCaption.setText(caption);
+        mProgressBar.setVisibility(View.VISIBLE);
     }
 
     private void hideProgressDialog() {
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
-        }
+        mCaption.setText("");
+        mProgressBar.setVisibility(View.INVISIBLE);
     }
 
     @Override

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/java/MainActivity.java
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/java/MainActivity.java
@@ -94,7 +94,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             @Override
             public void onReceive(Context context, Intent intent) {
                 Log.d(TAG, "onReceive:" + intent);
-                hideProgressDialog();
+                hideProgressBar();
 
                 switch (intent.getAction()) {
                     case MyDownloadService.DOWNLOAD_COMPLETED:
@@ -195,7 +195,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .setAction(MyUploadService.ACTION_UPLOAD));
 
         // Show loading spinner
-        showProgressDialog(getString(R.string.progress_uploading));
+        showProgressBar(getString(R.string.progress_uploading));
     }
 
     private void beginDownload() {
@@ -209,7 +209,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         startService(intent);
 
         // Show loading spinner
-        showProgressDialog(getString(R.string.progress_downloading));
+        showProgressBar(getString(R.string.progress_downloading));
     }
 
     private void launchCamera() {
@@ -223,13 +223,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private void signInAnonymously() {
         // Sign in anonymously. Authentication is required to read or write from Firebase Storage.
-        showProgressDialog(getString(R.string.progress_auth));
+        showProgressBar(getString(R.string.progress_auth));
         mAuth.signInAnonymously()
                 .addOnSuccessListener(this, new OnSuccessListener<AuthResult>() {
                     @Override
                     public void onSuccess(AuthResult authResult) {
                         Log.d(TAG, "signInAnonymously:SUCCESS");
-                        hideProgressDialog();
+                        hideProgressBar();
                         updateUI(authResult.getUser());
                     }
                 })
@@ -237,7 +237,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                     @Override
                     public void onFailure(@NonNull Exception exception) {
                         Log.e(TAG, "signInAnonymously:FAILURE", exception);
-                        hideProgressDialog();
+                        hideProgressBar();
                         updateUI(null);
                     }
                 });
@@ -281,12 +281,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         ad.show();
     }
 
-    private void showProgressDialog(String caption) {
+    private void showProgressBar(String caption) {
         mCaption.setText(caption);
         mProgressBar.setVisibility(View.VISIBLE);
     }
 
-    private void hideProgressDialog() {
+    private void hideProgressBar() {
         mCaption.setText("");
         mProgressBar.setVisibility(View.INVISIBLE);
     }

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.google.firebase.quickstart.firebasestorage.kotlin
 
 import android.app.Activity
-import android.app.ProgressDialog
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -21,10 +20,12 @@ import com.google.firebase.quickstart.firebasestorage.R
 import kotlinx.android.synthetic.main.activity_main.buttonCamera
 import kotlinx.android.synthetic.main.activity_main.buttonDownload
 import kotlinx.android.synthetic.main.activity_main.buttonSignIn
+import kotlinx.android.synthetic.main.activity_main.caption
 import kotlinx.android.synthetic.main.activity_main.layoutDownload
 import kotlinx.android.synthetic.main.activity_main.layoutSignin
 import kotlinx.android.synthetic.main.activity_main.layoutStorage
 import kotlinx.android.synthetic.main.activity_main.pictureDownloadUri
+import kotlinx.android.synthetic.main.activity_main.progressBar
 import java.util.Locale
 
 /**
@@ -37,7 +38,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
 
     private lateinit var broadcastReceiver: BroadcastReceiver
     private lateinit var auth: FirebaseAuth
-    private lateinit var progressDialog: ProgressDialog
 
     private var downloadUrl: Uri? = null
     private var fileUri: Uri? = null
@@ -53,9 +53,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         buttonCamera.setOnClickListener(this)
         buttonSignIn.setOnClickListener(this)
         buttonDownload.setOnClickListener(this)
-
-        progressDialog = ProgressDialog(this)
-        progressDialog.isIndeterminate = true
 
         // Local broadcast receiver
         broadcastReceiver = object : BroadcastReceiver() {
@@ -239,15 +236,14 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         ad.show()
     }
 
-    private fun showProgressDialog(caption: String) {
-        progressDialog.setMessage(caption)
-        progressDialog.show()
+    private fun showProgressDialog(progressCaption: String) {
+        caption.setText(progressCaption)
+        progressBar.visibility = View.VISIBLE
     }
 
     private fun hideProgressDialog() {
-        if (progressDialog.isShowing) {
-            progressDialog.dismiss()
-        }
+        caption.setText("")
+        progressBar.visibility = View.INVISIBLE
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
@@ -58,7 +58,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         broadcastReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 Log.d(TAG, "onReceive:$intent")
-                hideProgressDialog()
+                hideProgressBar()
 
                 when (intent.action) {
                     MyDownloadService.DOWNLOAD_COMPLETED -> {
@@ -156,7 +156,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
                 .setAction(MyUploadService.ACTION_UPLOAD))
 
         // Show loading spinner
-        showProgressDialog(getString(R.string.progress_uploading))
+        showProgressBar(getString(R.string.progress_uploading))
     }
 
     private fun beginDownload() {
@@ -171,7 +171,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             startService(intent)
 
             // Show loading spinner
-            showProgressDialog(getString(R.string.progress_downloading))
+            showProgressBar(getString(R.string.progress_downloading))
         }
     }
 
@@ -186,16 +186,16 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
 
     private fun signInAnonymously() {
         // Sign in anonymously. Authentication is required to read or write from Firebase Storage.
-        showProgressDialog(getString(R.string.progress_auth))
+        showProgressBar(getString(R.string.progress_auth))
         auth.signInAnonymously()
                 .addOnSuccessListener(this) { authResult ->
                     Log.d(TAG, "signInAnonymously:SUCCESS")
-                    hideProgressDialog()
+                    hideProgressBar()
                     updateUI(authResult.user)
                 }
                 .addOnFailureListener(this) { exception ->
                     Log.e(TAG, "signInAnonymously:FAILURE", exception)
-                    hideProgressDialog()
+                    hideProgressBar()
                     updateUI(null)
                 }
     }
@@ -236,12 +236,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         ad.show()
     }
 
-    private fun showProgressDialog(progressCaption: String) {
+    private fun showProgressBar(progressCaption: String) {
         caption.setText(progressCaption)
         progressBar.visibility = View.VISIBLE
     }
 
-    private fun hideProgressDialog() {
+    private fun hideProgressBar() {
         caption.setText("")
         progressBar.visibility = View.INVISIBLE
     }

--- a/storage/app/src/main/res/layout/activity_main.xml
+++ b/storage/app/src/main/res/layout/activity_main.xml
@@ -16,6 +16,21 @@
         android:paddingTop="@dimen/activity_vertical_margin"
         android:orientation="vertical">
 
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:indeterminate="true"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            style="?android:attr/progressBarStyleHorizontal"/>
+
+        <TextView
+            android:id="@+id/caption"
+            android:textAlignment="center"
+            android:textColor="@color/colorAccent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
         <ImageView
             android:id="@+id/firebaseLogo"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Follow up to #1010 
Replacing deprecated `ProgressDialog` with `ProgressBar` on the storage quickstart.


Update: using this same PR to update auth's `showProgressDialog()` and `hideProgressDialog()` to `showProgressBar()` and `hideProgressBar()` respectively.