### PR TITLE
refactor(mlkit): use ImageDecoder.decodeBitmap() on API >= 29

### DIFF
--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
@@ -92,7 +92,6 @@ public final class StillImageActivity extends AppCompatActivity {
   private Integer imageMaxWidth;
   // Max height (portrait mode)
   private Integer imageMaxHeight;
-  private Bitmap bitmapForDetection;
   private VisionImageProcessor imageProcessor;
 
   @Override
@@ -328,9 +327,8 @@ public final class StillImageActivity extends AppCompatActivity {
               true);
 
       preview.setImageBitmap(resizedBitmap);
-      bitmapForDetection = resizedBitmap;
 
-      imageProcessor.process(bitmapForDetection, graphicOverlay);
+      imageProcessor.process(resizedBitmap, graphicOverlay);
     } catch (IOException e) {
       Log.e(TAG, "Error retrieving saved image");
     }

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
@@ -80,7 +80,6 @@ public final class StillImageActivity extends AppCompatActivity {
   private static final int REQUEST_IMAGE_CAPTURE = 1001;
   private static final int REQUEST_CHOOSE_IMAGE = 1002;
 
-  private Button getImageButton;
   private ImageView preview;
   private GraphicOverlay graphicOverlay;
   private String selectedMode = CLOUD_LABEL_DETECTION;
@@ -102,7 +101,7 @@ public final class StillImageActivity extends AppCompatActivity {
 
     setContentView(R.layout.activity_still_image);
 
-    getImageButton = findViewById(R.id.getImageButton);
+    Button getImageButton = findViewById(R.id.getImageButton);
     getImageButton.setOnClickListener(
         new OnClickListener() {
           @Override

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/StillImageActivity.java
@@ -17,7 +17,9 @@ import android.content.ContentValues;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.graphics.ImageDecoder;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import androidx.appcompat.app.AppCompatActivity;
@@ -299,7 +301,13 @@ public final class StillImageActivity extends AppCompatActivity {
       // Clear the overlay first
       graphicOverlay.clear();
 
-      Bitmap imageBitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), imageUri);
+      Bitmap imageBitmap;
+      if (Build.VERSION.SDK_INT < 29) {
+        imageBitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), imageUri);
+      } else {
+        ImageDecoder.Source source = ImageDecoder.createSource(getContentResolver(), imageUri);
+        imageBitmap = ImageDecoder.decodeBitmap(source);
+      }
 
       // Get the dimensions of the View
       Pair<Integer, Integer> targetedSize = getTargetedWidthHeight();

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
@@ -34,6 +34,7 @@ import kotlinx.android.synthetic.main.activity_still_image.previewPane
 import kotlinx.android.synthetic.main.activity_still_image.sizeSelector
 import java.io.IOException
 import java.util.ArrayList
+import kotlin.math.max
 
 /** Activity demonstrating different image detector features with a still image from camera.  */
 @KeepName
@@ -247,7 +248,7 @@ class StillImageActivity : AppCompatActivity() {
             val maxHeight = targetedSize.second
 
             // Determine how much to scale down the image
-            val scaleFactor = Math.max(
+            val scaleFactor = max(
                     imageBitmap.width.toFloat() / targetWidth.toFloat(),
                     imageBitmap.height.toFloat() / maxHeight.toFloat())
 

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
@@ -52,7 +52,6 @@ class StillImageActivity : AppCompatActivity() {
     private var imageMaxWidth = 0
     // Max height (portrait mode)
     private var imageMaxHeight = 0
-    private var bitmapForDetection: Bitmap? = null
     private var imageProcessor: VisionImageProcessor? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -266,8 +265,7 @@ class StillImageActivity : AppCompatActivity() {
                     true)
 
             previewPane?.setImageBitmap(resizedBitmap)
-            bitmapForDetection = resizedBitmap
-            bitmapForDetection?.let {
+            resizedBitmap?.let {
                 imageProcessor?.process(it, previewOverlay)
             }
         } catch (e: IOException) {

--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/kotlin/StillImageActivity.kt
@@ -5,7 +5,9 @@ import android.content.ContentValues
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.ImageDecoder
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import androidx.appcompat.app.AppCompatActivity
@@ -239,7 +241,12 @@ class StillImageActivity : AppCompatActivity() {
             // Clear the overlay first
             previewOverlay?.clear()
 
-            val imageBitmap = MediaStore.Images.Media.getBitmap(contentResolver, imageUri)
+            val imageBitmap = if (Build.VERSION.SDK_INT < 29) {
+                MediaStore.Images.Media.getBitmap(contentResolver, imageUri)
+            } else {
+                val source = ImageDecoder.createSource(contentResolver, imageUri!!)
+                ImageDecoder.decodeBitmap(source)
+            }
 
             // Get the dimensions of the View
             val targetedSize = getTargetedWidthHeight()


### PR DESCRIPTION
Starting in API 29, [MediaStore.Images.Media.getBitmap()](https://developer.android.com/reference/android/provider/MediaStore.Images.Media.html#getBitmap(android.content.ContentResolver,%2520android.net.Uri)) has been deprecated. The docs recommend using [ImageDecoder.createSource()](https://developer.android.com/reference/android/graphics/ImageDecoder.html#createSource(android.content.ContentResolver,%2520android.net.Uri)) instead. This PR should make that replacement and (also in `StillImageActivity`):
- replace `Math.max()` with kotlin's `max()`;
- make `getImageButton` a local variable;
- remove unused variable `bitmapForDetection`.

Fixes #912