### PR TITLE
refactor(analytics): use androidx preference library

### DIFF
--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation "androidx.preference:preference-ktx:1.1.0"
 
     implementation 'com.google.firebase:firebase-core:17.2.1'
     implementation 'com.google.firebase:firebase-analytics:17.2.1'

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
@@ -25,7 +25,6 @@ import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -35,6 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.preference.PreferenceManager;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.firebase.analytics.FirebaseAnalytics;

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
@@ -3,7 +3,6 @@ package com.google.firebase.quickstart.analytics.kotlin
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -12,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
+import androidx.preference.PreferenceManager
 import androidx.viewpager.widget.ViewPager
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.quickstart.analytics.R


### PR DESCRIPTION
As mentioned in the [documentation](https://developer.android.com/reference/android/preference/PreferenceManager), `android.preference.PreferenceManager` has been deprecated in favor of `androidx.preference.PreferenceManager`. This PR should address that in our analytics sample app.