### PR TITLE
Fix provider for Apple in Kotlin version

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GenericIdpActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GenericIdpActivity.kt
@@ -153,7 +153,7 @@ class GenericIdpActivity : BaseActivity(), View.OnClickListener {
     companion object {
         private val TAG = "GenericIdp"
         private val PROVIDER_MAP = mapOf(
-                "Apple" to "apple,com",
+                "Apple" to "apple.com",
                 "Microsoft" to "microsoft.com",
                 "Yahoo" to "yahoo.com",
                 "Twitter" to "twitter.com"


### PR DESCRIPTION
- This  **enormous** 🎉 pull request fixes a typo in the provider mapping for Apple causing the Kotlin version of `GenericIdp` to never successfully log in.