### PR TITLE
refactor(firestore): Html --> HtmlCompat

### DIFF
--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     // Support Libs
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core:1.1.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'

--- a/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainActivity.java
+++ b/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainActivity.java
@@ -3,7 +3,6 @@ package com.google.firebase.example.fireeats.java;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.text.Html;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -16,6 +15,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.text.HtmlCompat;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -247,7 +247,8 @@ public class MainActivity extends AppCompatActivity implements
         mAdapter.setQuery(query);
 
         // Set header
-        mCurrentSearchView.setText(Html.fromHtml(filters.getSearchDescription(this)));
+        mCurrentSearchView.setText(HtmlCompat.fromHtml(filters.getSearchDescription(this),
+                HtmlCompat.FROM_HTML_MODE_LEGACY));
         mCurrentSortByView.setText(filters.getOrderDescription(this));
 
         // Save filters

--- a/firestore/app/src/main/java/com/google/firebase/example/fireeats/kotlin/MainActivity.kt
+++ b/firestore/app/src/main/java/com/google/firebase/example/fireeats/kotlin/MainActivity.kt
@@ -3,7 +3,6 @@ package com.google.firebase.example.fireeats.kotlin
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.text.Html
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -11,6 +10,7 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.firebase.ui.auth.AuthUI
@@ -204,7 +204,8 @@ class MainActivity : AppCompatActivity(),
         adapter.setQuery(query)
 
         // Set header
-        textCurrentSearch.text = Html.fromHtml(filters.getSearchDescription(this))
+        textCurrentSearch.text = HtmlCompat.fromHtml(filters.getSearchDescription(this),
+                HtmlCompat.FROM_HTML_MODE_LEGACY)
         textCurrentSortBy.text = filters.getOrderDescription(this)
 
         // Save filters


### PR DESCRIPTION
Another one on the deprecation saga. 

This PR should replace the deprecated [`Html.fromHtml()`](https://developer.android.com/reference/android/text/Html.html#fromHtml(java.lang.String)) method with `HtmlCompat.fromHtml()`, as recommended on this [post](https://stackoverflow.com/a/37905107/5861618).