### PR TITLE
Fix failing tests in InvalidImportDetectorTestCall.kt

### DIFF
--- a/internal/lint/src/test/java/com/firebase/lint/InvalidImportDetectorTest.kt
+++ b/internal/lint/src/test/java/com/firebase/lint/InvalidImportDetectorTest.kt
@@ -18,6 +18,7 @@ class InvalidImportDetectorTest {
     @Test
     fun normalRImport() {
         lint()
+                .allowMissingSdk()
                 .files(javaPackage, java("""
           package com.google.firebase.kotlin;
 
@@ -33,6 +34,7 @@ class InvalidImportDetectorTest {
     @Test
     fun wrongImport() {
         lint()
+                .allowMissingSdk()
                 .files(javaPackage, java("""
           package com.google.firebase.kotlin;
 


### PR DESCRIPTION
Call `allowMissingSdk()` in `InvalidImportDetectorTestCall.kt` to avoid the following error ...
```
java.lang.AssertionError: This test requires an Android SDK: No SDK configured.
```
... and make tests pass.