### PR TITLE
Remove memory leak from CustomImageClassifier.java

### DIFF
--- a/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/custommodel/CustomImageClassifier.java
+++ b/mlkit/app/src/main/java/com/google/firebase/samples/apps/mlkit/java/custommodel/CustomImageClassifier.java
@@ -268,10 +268,11 @@ public class CustomImageClassifier {
             ByteBuffer buffer, int width, int height) {
         int bytesPerChannel = mUseQuantizedModel ? QUANT_NUM_OF_BYTES_PER_CHANNEL :
                 FLOAT_NUM_OF_BYTES_PER_CHANNEL;
-        if (this.imgData == null)
+        if (this.imgData == null) {
             this.imgData = ByteBuffer.allocateDirect(bytesPerChannel * DIM_BATCH_SIZE * DIM_IMG_SIZE_X * DIM_IMG_SIZE_Y * DIM_PIXEL_SIZE);
-        else
+        } else {
             this.imgData.clear();
+        }
 
         this.imgData.order(ByteOrder.nativeOrder());
         Bitmap bitmap = createResizedBitmap(buffer, width, height);


### PR DESCRIPTION
The imgData variable in convertBitmapToByteBuffer function was being assigned a new byte[] each time, and the last used byte[] were not being removed from memory which was causing a memory leak. The variable was made a property of the class and was initiated only once, cleared and reused again.