### PR TITLE
refactor: ViewModelProviders --> ViewModelProvider

### DIFF
--- a/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainActivity.java
+++ b/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainActivity.java
@@ -16,7 +16,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.text.HtmlCompat;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -84,7 +84,7 @@ public class MainActivity extends AppCompatActivity implements
         findViewById(R.id.buttonClearFilter).setOnClickListener(this);
 
         // View model
-        mViewModel = ViewModelProviders.of(this).get(MainActivityViewModel.class);
+        mViewModel = new ViewModelProvider(this).get(MainActivityViewModel.class);
 
         // Enable Firestore logging
         FirebaseFirestore.setLoggingEnabled(true);

--- a/mlkit-smartreply/app/src/main/java/com/google/firebase/samples/apps/mlkit/smartreply/java/chat/ChatFragment.java
+++ b/mlkit-smartreply/app/src/main/java/com/google/firebase/samples/apps/mlkit/smartreply/java/chat/ChatFragment.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -69,7 +69,7 @@ public class ChatFragment extends Fragment implements ReplyChipAdapter.ClickList
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        mViewModel = ViewModelProviders.of(this).get(ChatViewModel.class);
+        mViewModel = new ViewModelProvider(this).get(ChatViewModel.class);
 
         mChatRecycler = view.findViewById(R.id.chatHistory);
         mEmulatedUserText = view.findViewById(R.id.switchText);

--- a/mlkit-smartreply/app/src/main/java/com/google/firebase/samples/apps/mlkit/smartreply/kotlin/chat/ChatFragment.kt
+++ b/mlkit-smartreply/app/src/main/java/com/google/firebase/samples/apps/mlkit/smartreply/kotlin/chat/ChatFragment.kt
@@ -16,7 +16,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.firebase.samples.apps.mlkit.smartreply.R
@@ -56,7 +56,7 @@ class ChatFragment : Fragment(), ReplyChipAdapter.ClickListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel = ViewModelProviders.of(this).get(ChatViewModel::class.java)
+        viewModel = ViewModelProvider(this).get(ChatViewModel::class.java)
 
         chatRecycler = view.findViewById(R.id.chatHistory)
         emulatedUserText = view.findViewById(R.id.switchText)

--- a/mlkit-translate/app/src/main/java/com/google/firebase/samples/apps/mlkit/translate/java/TranslateFragment.java
+++ b/mlkit-translate/app/src/main/java/com/google/firebase/samples/apps/mlkit/translate/java/TranslateFragment.java
@@ -35,7 +35,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.firebase.samples.apps.mlkit.translate.R;
@@ -78,8 +78,7 @@ public class TranslateFragment extends Fragment {
         final Spinner sourceLangSelector = view.findViewById(R.id.sourceLangSelector);
         final Spinner targetLangSelector = view.findViewById(R.id.targetLangSelector);
 
-        final TranslateViewModel viewModel =
-                ViewModelProviders.of(this).get(TranslateViewModel.class);
+        final TranslateViewModel viewModel = new ViewModelProvider(this).get(TranslateViewModel.class);
 
         // Get available language list and set up source and target language spinners
         // with default selections.

--- a/mlkit-translate/app/src/main/java/com/google/firebase/samples/apps/mlkit/translate/kotlin/TranslateFragment.kt
+++ b/mlkit-translate/app/src/main/java/com/google/firebase/samples/apps/mlkit/translate/kotlin/TranslateFragment.kt
@@ -28,7 +28,7 @@ import android.widget.ArrayAdapter
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.samples.apps.mlkit.translate.R
 import com.google.firebase.samples.apps.mlkit.translate.kotlin.TranslateViewModel.Language
 import kotlinx.android.synthetic.main.translate_fragment.buttonSwitchLang
@@ -59,7 +59,7 @@ class TranslateFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val viewModel = ViewModelProviders.of(this).get(TranslateViewModel::class.java)
+        val viewModel = ViewModelProvider(this).get(TranslateViewModel::class.java)
 
         // Get available language list and set up source and target language spinners
         // with default selections.


### PR DESCRIPTION
Starting in version 2.2.0 of the lifecycle library, the [ViewModelProviders](https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModelProviders) class has been deprecated. We should now use the [ViewModelProvider](https://developer.android.com/reference/androidx/lifecycle/ViewModelProvider) constructor instead.