### PR TITLE
test: replace deprecated AndroidJUnit4

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
 }
 

--- a/admob/app/src/androidTest/java/com/google/samples/quickstart/admobexample/InterstitialAdTest.java
+++ b/admob/app/src/androidTest/java/com/google/samples/quickstart/admobexample/InterstitialAdTest.java
@@ -1,10 +1,10 @@
 package com.google.samples.quickstart.admobexample;
 
 
-import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import com.google.samples.quickstart.admobexample.java.MainActivity;
@@ -36,12 +36,12 @@ public class InterstitialAdTest {
     @Before
     public void setUp() {
         mAdResource = new AdViewIdlingResource(mActivityTestRule.getActivity().getAdView());
-        Espresso.registerIdlingResources(mAdResource);
+        IdlingRegistry.getInstance().register(mAdResource);
     }
 
     @After
     public void tearDown() {
-        Espresso.unregisterIdlingResources(mAdResource);
+        IdlingRegistry.getInstance().unregister(mAdResource);
     }
 
     @Test

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/analytics/app/src/androidTest/java/com/google/firebase/quickstart/analytics/MainActivityTest.java
+++ b/analytics/app/src/androidTest/java/com/google/firebase/quickstart/analytics/MainActivityTest.java
@@ -4,8 +4,8 @@ package com.google.firebase.quickstart.analytics;
 import androidx.annotation.StringRes;
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import com.google.firebase.quickstart.analytics.java.MainActivity;

--- a/app-indexing/app/build.gradle
+++ b/app-indexing/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app-indexing/app/src/androidTest/java/com/google/samples/quickstart/appindexing/MainActivityTest.java
+++ b/app-indexing/app/src/androidTest/java/com/google/samples/quickstart/appindexing/MainActivityTest.java
@@ -17,8 +17,9 @@ package com.google.samples.quickstart.appindexing;
 
 import android.content.Intent;
 import android.net.Uri;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import com.google.samples.quickstart.appindexing.java.MainActivity;
 

--- a/app-indexing/app/src/androidTest/java/com/google/samples/quickstart/appindexing/kotlin/MainActivityTest.kt
+++ b/app-indexing/app/src/androidTest/java/com/google/samples/quickstart/appindexing/kotlin/MainActivityTest.kt
@@ -6,8 +6,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
 import com.google.samples.quickstart.appindexing.java.MainActivity
 import org.junit.Rule
 import org.junit.Test

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/config/app/src/androidTest/java/com/google/samples/quickstart/config/MainActivityTest.java
+++ b/config/app/src/androidTest/java/com/google/samples/quickstart/config/MainActivityTest.java
@@ -1,7 +1,7 @@
 package com.google.samples.quickstart.config;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import com.google.samples.quickstart.config.java.MainActivity;
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 public class MainActivityTest {
 
     @Rule
-    public ActivityTestRule<MainActivity> rule = new ActivityTestRule<MainActivity>(MainActivity.class);
+    public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 
     @Test
     public void testFetchConfig() {

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
 }
 

--- a/crash/app/src/androidTest/java/com/google/samples/quickstart/crash/MainActivityTest.java
+++ b/crash/app/src/androidTest/java/com/google/samples/quickstart/crash/MainActivityTest.java
@@ -2,8 +2,8 @@ package com.google.samples.quickstart.crash;
 
 
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import android.widget.CheckBox;
 

--- a/dynamiclinks/app/build.gradle
+++ b/dynamiclinks/app/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/dynamiclinks/app/src/androidTest/java/com/google/firebase/quickstart/deeplinks/MainActivityTest.java
+++ b/dynamiclinks/app/src/androidTest/java/com/google/firebase/quickstart/deeplinks/MainActivityTest.java
@@ -3,8 +3,9 @@ package com.google.firebase.quickstart.deeplinks;
 
 import android.content.Intent;
 import android.net.Uri;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import com.google.firebase.quickstart.deeplinks.java.MainActivity;
 


### PR DESCRIPTION
`androidx.test.runner.AndroidJUnit4` is now deprecated in favor of `androidx.test.ext.junit.runners.AndroidJUnit4`. This PR should update our tests to use the new class instead.

Additionally, it should replace the deprecated functions `Espresso.registerIdlingResources()` and `Espresso.unregisterIdlingResources()` with `IdlingRegistry.getInstance().register()` and `IdlingRegistry.getInstance().unregister()` respectively.