### PR TITLE
refactor(auth): change firebaseAuthWithGoogle() argument type

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInActivity.java
@@ -104,7 +104,8 @@ public class GoogleSignInActivity extends BaseActivity implements
             try {
                 // Google Sign In was successful, authenticate with Firebase
                 GoogleSignInAccount account = task.getResult(ApiException.class);
-                firebaseAuthWithGoogle(account);
+                Log.d(TAG, "firebaseAuthWithGoogle:" + account.getId());
+                firebaseAuthWithGoogle(account.getIdToken());
             } catch (ApiException e) {
                 // Google Sign In failed, update UI appropriately
                 Log.w(TAG, "Google sign in failed", e);
@@ -117,13 +118,11 @@ public class GoogleSignInActivity extends BaseActivity implements
     // [END onactivityresult]
 
     // [START auth_with_google]
-    private void firebaseAuthWithGoogle(GoogleSignInAccount acct) {
-        Log.d(TAG, "firebaseAuthWithGoogle:" + acct.getId());
+    private void firebaseAuthWithGoogle(String idToken) {
         // [START_EXCLUDE silent]
         showProgressBar();
         // [END_EXCLUDE]
-
-        AuthCredential credential = GoogleAuthProvider.getCredential(acct.getIdToken(), null);
+        AuthCredential credential = GoogleAuthProvider.getCredential(idToken, null);
         mAuth.signInWithCredential(credential)
                 .addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
                     @Override

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -58,7 +58,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
     }
 
     // [START on_start_check_user]
-    public override fun onStart() {
+    override fun onStart() {
         super.onStart()
         // Check if user is signed in (non-null) and update UI accordingly.
         val currentUser = auth.currentUser
@@ -67,7 +67,7 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
     // [END on_start_check_user]
 
     // [START onactivityresult]
-    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
         // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -105,7 +105,10 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
                     } else {
                         // If sign in fails, display a message to the user.
                         Log.w(TAG, "signInWithCredential:failure", task.exception)
-                        Snackbar.make(binding.mainLayout, "Authentication Failed.", Snackbar.LENGTH_SHORT).show()
+                        // [START_EXCLUDE]
+                        val view = binding.mainLayout
+                        // [END_EXCLUDE]
+                        Snackbar.make(view, "Authentication Failed.", Snackbar.LENGTH_SHORT).show()
                         updateUI(null)
                     }
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInActivity.kt
@@ -75,8 +75,9 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
             val task = GoogleSignIn.getSignedInAccountFromIntent(data)
             try {
                 // Google Sign In was successful, authenticate with Firebase
-                val account = task.getResult(ApiException::class.java)
-                firebaseAuthWithGoogle(account!!)
+                val account = task.getResult(ApiException::class.java)!!
+                Log.d(TAG, "firebaseAuthWithGoogle:" + account.id)
+                firebaseAuthWithGoogle(account.idToken!!)
             } catch (e: ApiException) {
                 // Google Sign In failed, update UI appropriately
                 Log.w(TAG, "Google sign in failed", e)
@@ -89,13 +90,11 @@ class GoogleSignInActivity : BaseActivity(), View.OnClickListener {
     // [END onactivityresult]
 
     // [START auth_with_google]
-    private fun firebaseAuthWithGoogle(acct: GoogleSignInAccount) {
-        Log.d(TAG, "firebaseAuthWithGoogle:" + acct.id!!)
+    private fun firebaseAuthWithGoogle(idToken: String) {
         // [START_EXCLUDE silent]
         showProgressBar()
         // [END_EXCLUDE]
-
-        val credential = GoogleAuthProvider.getCredential(acct.idToken, null)
+        val credential = GoogleAuthProvider.getCredential(idToken, null)
         auth.signInWithCredential(credential)
                 .addOnCompleteListener(this) { task ->
                     if (task.isSuccessful) {


### PR DESCRIPTION
The main reason why I've opened this PR is to change the `firebaseAuthWithGoogle()` function to take a googleIdToken (`String`) as argument instead of `GoogleSignInAccount`. Since some Auth libraries like [One Tap UI](https://developers.google.com/identity/one-tap/android/get-saved-credentials#sign_in_with_retrieved_credentials) actually return google id tokens, we could reuse the `firebaseAuthWithGoogle()` method to handle both: a simple google sign in and a google sign with One Tap UI.


---
Additionally, I've found a few smaller issues and I fixed them:
- some Kotlin function declarations had `public` on their signature
- the `binding` property was exposed in a snippet