### PR TITLE
refactor(storage): use the new Kotlin Destructuring Declarations

### DIFF
--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MyDownloadService.kt
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MyDownloadService.kt
@@ -9,6 +9,8 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.quickstart.firebasestorage.R
 import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.ktx.component1
+import com.google.firebase.storage.ktx.component2
 import com.google.firebase.storage.ktx.storage
 
 class MyDownloadService : MyBaseTaskService() {
@@ -46,8 +48,7 @@ class MyDownloadService : MyBaseTaskService() {
         showProgressNotification(getString(R.string.progress_downloading), 0, 0)
 
         // Download and get total bytes
-        storageRef.child(downloadPath).getStream { taskSnapshot, inputStream ->
-            val totalBytes = taskSnapshot.totalByteCount
+        storageRef.child(downloadPath).getStream { (_, totalBytes), inputStream ->
             var bytesDownloaded: Long = 0
 
             val buffer = ByteArray(1024)
@@ -63,12 +64,12 @@ class MyDownloadService : MyBaseTaskService() {
 
             // Close the stream at the end of the Task
             inputStream.close()
-        }.addOnSuccessListener { taskSnapshot ->
+        }.addOnSuccessListener { (_, totalBytes) ->
             Log.d(TAG, "download:SUCCESS")
 
             // Send success broadcast with number of bytes downloaded
-            broadcastDownloadFinished(downloadPath, taskSnapshot.totalByteCount)
-            showDownloadFinishedNotification(downloadPath, taskSnapshot.totalByteCount.toInt())
+            broadcastDownloadFinished(downloadPath, totalBytes)
+            showDownloadFinishedNotification(downloadPath, totalBytes.toInt())
 
             // Mark task completed
             taskCompleted()

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MyUploadService.kt
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MyUploadService.kt
@@ -1,6 +1,5 @@
 package com.google.firebase.quickstart.firebasestorage.kotlin
 
-import android.app.Service
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.Uri
@@ -11,6 +10,8 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.quickstart.firebasestorage.R
 import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.ktx.component1
+import com.google.firebase.storage.ktx.component2
 import com.google.firebase.storage.ktx.storage
 
 /**
@@ -49,12 +50,12 @@ class MyUploadService : MyBaseTaskService() {
             uploadFromUri(fileUri)
         }
 
-        return Service.START_REDELIVER_INTENT
+        return START_REDELIVER_INTENT
     }
 
     // [START upload_from_uri]
     private fun uploadFromUri(fileUri: Uri) {
-        Log.d(TAG, "uploadFromUri:src:" + fileUri.toString())
+        Log.d(TAG, "uploadFromUri:src:$fileUri")
 
         // [START_EXCLUDE]
         taskStarted()
@@ -70,10 +71,10 @@ class MyUploadService : MyBaseTaskService() {
 
             // Upload file to Firebase Storage
             Log.d(TAG, "uploadFromUri:dst:" + photoRef.path)
-            photoRef.putFile(fileUri).addOnProgressListener { taskSnapshot ->
+            photoRef.putFile(fileUri).addOnProgressListener { (bytesTransferred, totalByteCount) ->
                 showProgressNotification(getString(R.string.progress_uploading),
-                        taskSnapshot.bytesTransferred,
-                        taskSnapshot.totalByteCount)
+                        bytesTransferred,
+                        totalByteCount)
             }.continueWithTask { task ->
                 // Forward any exceptions
                 if (!task.isSuccessful) {


### PR DESCRIPTION
This PR should update our storage sample app to use the Kotlin Destructuring Declarations introduced in `storage-ktx:19.2.0`.

It also fixes a couple of warnings on `MyUploadService.kt`:
- The `Service` import is redundant.
- `Log.d()` can use String template instead of String concatenation.