### PR TITLE
chore(*): remove kotlin-stdlib-jdk7 dependency

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -29,7 +29,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app-indexing/app/build.gradle
+++ b/app-indexing/app/build.gradle
@@ -28,7 +28,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
     // [START app_indexing_gradle_dep]
     implementation 'com.google.firebase:firebase-appindexing:19.1.0'
     // [END app_indexing_gradle_dep]

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -30,7 +30,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'com.google.android.material:material:1.2.1'
 

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -36,7 +36,6 @@ androidExtensions {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/dynamiclinks/app/build.gradle
+++ b/dynamiclinks/app/build.gradle
@@ -44,7 +44,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'com.google.android.material:material:1.2.1'
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -43,7 +43,6 @@ androidExtensions {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     // Firestore (Java)
     implementation 'com.google.firebase:firebase-firestore:21.6.0'

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -32,7 +32,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -33,7 +33,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -37,7 +37,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(':internal:chooserx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'androidx.camera:camera-camera2:1.0.0-beta08'
     implementation 'androidx.camera:camera-core:1.0.0-beta08'

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -36,7 +36,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     implementation 'com.google.firebase:firebase-perf:19.0.8'
 

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -30,7 +30,6 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0"
 
     // Storage (Java)
     implementation 'com.google.firebase:firebase-storage:19.2.0'


### PR DESCRIPTION
Starting in Kotlin 1.4.0, the kotlin-stdlib is [added by default](https://kotlinlang.org/docs/reference/whatsnew14.html#dependency-on-the-standard-library-added-by-default). So we no longer need it on our build.gradle files.