### PR TITLE
refactor(admob, analytics): replace deprecated methods

### DIFF
--- a/admob/app/src/main/java/com/google/samples/quickstart/admobexample/java/MainActivity.java
+++ b/admob/app/src/main/java/com/google/samples/quickstart/admobexample/java/MainActivity.java
@@ -60,7 +60,7 @@ public class MainActivity extends AppCompatActivity {
         checkIds();
 
         // Initialize the Google Mobile Ads SDK
-        MobileAds.initialize(this, getString(R.string.admob_app_id));
+        MobileAds.initialize(this);
 
         mAdView = findViewById(R.id.adView);
         AdRequest adRequest = new AdRequest.Builder().build();

--- a/admob/app/src/main/java/com/google/samples/quickstart/admobexample/kotlin/MainActivity.kt
+++ b/admob/app/src/main/java/com/google/samples/quickstart/admobexample/kotlin/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : AppCompatActivity() {
         checkIds()
 
         // Initialize the Google Mobile Ads SDK
-        MobileAds.initialize(this, getString(R.string.admob_app_id))
+        MobileAds.initialize(this)
 
         val adRequest = AdRequest.Builder().build()
 

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
@@ -255,7 +255,7 @@ public class MainActivity extends AppCompatActivity {
      * we change fragments.
      */
     private void recordScreenView() {
-        // This string must be <= 36 characters long in order for setCurrentScreen to succeed.
+        // This string must be <= 36 characters long.
         String screenName = getCurrentImageId() + "-" + getCurrentImageTitle();
 
         // [START set_current_screen]

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/java/MainActivity.java
@@ -259,7 +259,10 @@ public class MainActivity extends AppCompatActivity {
         String screenName = getCurrentImageId() + "-" + getCurrentImageTitle();
 
         // [START set_current_screen]
-        mFirebaseAnalytics.setCurrentScreen(this, screenName, null /* class override */);
+        Bundle bundle = new Bundle();
+        bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName);
+        bundle.putString(FirebaseAnalytics.Param.SCREEN_CLASS, "MainActivity");
+        mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle);
         // [END set_current_screen]
     }
 

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
@@ -212,7 +212,7 @@ class MainActivity : AppCompatActivity() {
      * we change fragments.
      */
     private fun recordScreenView() {
-        // This string must be <= 36 characters long in order for setCurrentScreen to succeed.
+        // This string must be <= 36 characters long.
         val screenName = "${getCurrentImageId()}-${getCurrentImageTitle()}"
 
         // [START set_current_screen]

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
@@ -216,7 +216,10 @@ class MainActivity : AppCompatActivity() {
         val screenName = "${getCurrentImageId()}-${getCurrentImageTitle()}"
 
         // [START set_current_screen]
-        firebaseAnalytics.setCurrentScreen(this, screenName, null /* class override */)
+        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+            param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
+            param(FirebaseAnalytics.Param.SCREEN_CLASS, "MainActivity")
+        }
         // [END set_current_screen]
     }
 


### PR DESCRIPTION
This PR should replace 2 deprecated methods:
1. [`MobileAds.initialize()`](https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds#public-static-void-initialize-context-context,-string-applicationcode) in the admob sample app;
2. [`FirebaseAnalytics.setCurrentScreen()`](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#setCurrentScreen(android.app.Activity,%20java.lang.String,%20java.lang.String)) in the analytics sample app.

Worth pointing out that the analytics snippet is shown in the [Documentation](https://firebase.google.com/docs/analytics/screenviews#kotlin+ktx) and a change may be in order to remove this last line bellow the snippet:

![Screenshot from 2020-09-17 19-53-19](https://user-images.githubusercontent.com/16766726/93509220-b7bada80-f91f-11ea-9b62-6f35eb37551e.png)
