### PR TITLE
refactor(auth): fix kotlin errors and improve chooser layout

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/ChooserActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/ChooserActivity.kt
@@ -34,7 +34,7 @@ class ChooserActivity : AppCompatActivity(), AdapterView.OnItemClickListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityChooserBinding.inflate(layoutInflater)
-        setContentView(R.layout.activity_chooser)
+        setContentView(binding.root)
 
         // Set up Adapter
         val adapter = MyArrayAdapter(this, android.R.layout.simple_list_item_2, CLASSES as Array<Class<*>>)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/MultiFactorActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/MultiFactorActivity.kt
@@ -24,7 +24,7 @@ class MultiFactorActivity : BaseActivity(), View.OnClickListener {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMultiFactorBinding.inflate(layoutInflater)
-        setContentView(binding.reloadButton)
+        setContentView(binding.root)
         setProgressBar(binding.progressBar)
 
         // Buttons

--- a/auth/app/src/main/res/layout/activity_chooser.xml
+++ b/auth/app/src/main/res/layout/activity_chooser.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin">
+    android:layout_height="match_parent">
 
     <ListView
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-</LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Fixing 2 errors here:
- `setContentView()` was being called with the wrong argument in ChooserActivity, causing the `ListView` to not be shown
- On MultiFactorActivity, `setContentView()` was being called with an incompatible `View`, causing the app to crash.

This PR should also remove the padding around the ListView in ChooserActivity and replace its `LinearLayout` with a `FrameLayout`.