### PR TITLE
docs(functions): fix StackOverflow url in README.md

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -37,7 +37,7 @@ Screenshots
 Support
 -------
 
-- [Stack Overflow](https://stackoverflow.com/questions/tagged/firebase-crash-reporting)
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/google-cloud-functions)
 - [Firebase Support](https://firebase.google.com/support/)
 
 License


### PR DESCRIPTION
The StackOverflow URL in our functions README.md was incorrect.