### PR TITLE
refactor(perfmon): replace deprecated AsyncTask and Tasks.call()

### DIFF
--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
 
     implementation 'com.github.bumptech.glide:glide:3.7.0'
 


### PR DESCRIPTION
This should replace 2 deprecations:
- `AsyncTask`
    - In the Java quickstart, I replaced it with `Executors.newSingleThreadExecutor()`.
    - In the Kotlin quickstart, I replaced it with a Kotlin Coroutine which I'm launching with the helper `lifecycleScope` KTX from the `lifecycle-runtime-ktx` library.
- `Tasks.call()` - replaced with a `TaskCompletionSource<T>`.