### PR TITLE
refactor(database, firestore): remove kotlin synthetic binding

### DIFF
--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.kotlin.android.extensions'
 
 check.dependsOn 'assembleDebugAndroidTest'
 
@@ -27,10 +26,6 @@ android {
     buildFeatures {
         viewBinding = true
     }
-}
-
-androidExtensions {
-    experimental = true
 }
 
 dependencies {

--- a/database/app/src/main/java/com/google/firebase/quickstart/database/kotlin/viewholder/PostViewHolder.kt
+++ b/database/app/src/main/java/com/google/firebase/quickstart/database/kotlin/viewholder/PostViewHolder.kt
@@ -2,30 +2,32 @@ package com.google.firebase.quickstart.database.kotlin.viewholder
 
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import com.google.firebase.quickstart.database.R
 import com.google.firebase.quickstart.database.kotlin.models.Post
-import kotlinx.android.synthetic.main.include_post_author.view.postAuthor
-import kotlinx.android.synthetic.main.include_post_text.view.postBody
-import kotlinx.android.synthetic.main.include_post_text.view.postTitle
-import kotlinx.android.synthetic.main.item_post.view.postNumStars
-import kotlinx.android.synthetic.main.item_post.view.star
 
 class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    private val postTitle: TextView = itemView.findViewById(R.id.postTitle)
+    private val postAuthor: TextView = itemView.findViewById(R.id.postAuthor)
+    private val postNumStars: TextView = itemView.findViewById(R.id.postNumStars)
+    private val postBody: TextView = itemView.findViewById(R.id.postBody)
+    private val star: ImageView = itemView.findViewById(R.id.star)
 
     fun bindToPost(post: Post, starClickListener: View.OnClickListener) {
-        itemView.postTitle.text = post.title
-        itemView.postAuthor.text = post.author
-        itemView.postNumStars.text = post.starCount.toString()
-        itemView.postBody.text = post.body
+        postTitle.text = post.title
+        postAuthor.text = post.author
+        postNumStars.text = post.starCount.toString()
+        postBody.text = post.body
 
-        itemView.star.setOnClickListener(starClickListener)
+        star.setOnClickListener(starClickListener)
     }
 
     fun setLikedState(liked: Boolean) {
         if (liked) {
-            itemView.star.setImageResource(R.drawable.ic_toggle_star_24)
+            star.setImageResource(R.drawable.ic_toggle_star_24)
         } else {
-            itemView.star.setImageResource(R.drawable.ic_toggle_star_outline_24)
+            star.setImageResource(R.drawable.ic_toggle_star_outline_24)
         }
     }
 }

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.kotlin.android.extensions'
 
 android {
     testBuildType "release"
@@ -34,10 +33,6 @@ android {
     buildFeatures {
         viewBinding = true
     }
-}
-
-androidExtensions {
-    experimental = true
 }
 
 dependencies {


### PR DESCRIPTION
Seems like we missed 2 quickstarts when removing Kotlin Synthetic Binding, which is [now deprecated](https://android-developers.googleblog.com/2020/11/the-future-of-kotlin-android-extensions.html).