### PR TITLE
Updated comments for more clarity on when onNewToken is called

### DIFF
--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
@@ -104,10 +104,13 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
     // [START on_new_token]
     /**
-     * Called if FCM registration token is updated. This may occur if the security of
-     * the previous token had been compromised. Note that this is called when the
-     * FCM registration token is initially generated so this is where you would retrieve
-     * the token.
+     * There are two scenarios when onNewToken is called:
+     * 1) When a new token is generated on initial app startup
+     * 2) Whenever an existing token is changed
+     * Under #2, there are three scenarios when the existing token is changed:
+     * A) App is restored to a new device
+     * B) User uninstalls/reinstalls the app
+     * C) User clears app data
      */
     @Override
     public void onNewToken(String token) {


### PR DESCRIPTION
Given the lengthy history of obtaining the token from C2DM, GCM, FCM, and the transition from InstanceID to Installation SDK, added additional clarity to outline all the known scenarios onNewToken is called to match with the details from https://firebase.google.com/docs/cloud-messaging/android/client#sample-register
Attempting to prevent reading multiple blog posts and docs to understand when to use the method in the sample and rather incorporate the latest known information into the sample by updating the previous comments to the latest information