### PR TITLE
refactor(admob): create a separate nav graph for the java sample

### DIFF
--- a/admob/app/src/main/java/com/google/samples/quickstart/admobexample/java/MainActivity.java
+++ b/admob/app/src/main/java/com/google/samples/quickstart/admobexample/java/MainActivity.java
@@ -17,6 +17,7 @@ package com.google.samples.quickstart.admobexample.java;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.navigation.Navigation;
 
 import com.google.samples.quickstart.admobexample.R;
 
@@ -26,6 +27,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        Navigation.findNavController(this, R.id.nav_host_fragment).setGraph(R.navigation.nav_graph_java);
     }
 
 }

--- a/admob/app/src/main/java/com/google/samples/quickstart/admobexample/kotlin/MainActivity.kt
+++ b/admob/app/src/main/java/com/google/samples/quickstart/admobexample/kotlin/MainActivity.kt
@@ -2,6 +2,7 @@ package com.google.samples.quickstart.admobexample.kotlin
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
 import com.google.samples.quickstart.admobexample.R
 
 class MainActivity : AppCompatActivity() {
@@ -9,5 +10,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        findNavController(R.id.nav_host_fragment).setGraph(R.navigation.nav_graph_kotlin)
     }
 }

--- a/admob/app/src/main/res/layout/activity_main.xml
+++ b/admob/app/src/main/res/layout/activity_main.xml
@@ -15,7 +15,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/nav_graph" />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/admob/app/src/main/res/navigation/nav_graph_java.xml
+++ b/admob/app/src/main/res/navigation/nav_graph_java.xml
@@ -2,12 +2,12 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/nav_graph"
+    android:id="@+id/nav_graph_java"
     app:startDestination="@id/FirstFragment">
 
     <fragment
         android:id="@+id/FirstFragment"
-        android:name="com.google.samples.quickstart.admobexample.kotlin.FirstFragment"
+        android:name="com.google.samples.quickstart.admobexample.java.FirstFragment"
         android:label="@string/first_fragment_title"
         tools:layout="@layout/fragment_first">
 
@@ -17,7 +17,7 @@
     </fragment>
     <fragment
         android:id="@+id/SecondFragment"
-        android:name="com.google.samples.quickstart.admobexample.kotlin.SecondFragment"
+        android:name="com.google.samples.quickstart.admobexample.java.SecondFragment"
         android:label="@string/second_fragment_title"
         tools:layout="@layout/fragment_second">
     </fragment>

--- a/admob/app/src/main/res/navigation/nav_graph_kotlin.xml
+++ b/admob/app/src/main/res/navigation/nav_graph_kotlin.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph_kotlin"
+    app:startDestination="@id/FirstFragment">
+
+    <fragment
+        android:id="@+id/FirstFragment"
+        android:name="com.google.samples.quickstart.admobexample.kotlin.FirstFragment"
+        android:label="@string/first_fragment_title"
+        tools:layout="@layout/fragment_first">
+
+        <action
+            android:id="@+id/action_FirstFragment_to_SecondFragment"
+            app:destination="@id/SecondFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/SecondFragment"
+        android:name="com.google.samples.quickstart.admobexample.kotlin.SecondFragment"
+        android:label="@string/second_fragment_title"
+        tools:layout="@layout/fragment_second">
+    </fragment>
+</navigation>


### PR DESCRIPTION
I noticed I made a mistake when I sent #1247 : I only added the Kotlin Fragments to the navigation graph, which caused the java ones to never be used.

As a solution (in this PR), I've created a separate nav graph file for the java fragments (`nav_graph_java.xml`) and the graphs are now set programmatically (instead of setting it in the XML layout).