### PR TITLE
refactor(app-indexing): update to 19.2.0

### DIFF
--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/AppIndexingService.java
@@ -18,7 +18,8 @@ public class AppIndexingService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-        final Task<Void> setStickersTask = AppIndexingUtil.setStickers(getApplicationContext(), FirebaseAppIndex.getInstance());
+        final Task<Void> setStickersTask = AppIndexingUtil.setStickers(getApplicationContext(),
+                FirebaseAppIndex.getInstance(getApplicationContext()));
         if (setStickersTask != null) {
            try {
                Tasks.await(setStickersTask); 

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/MainActivity.java
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/java/MainActivity.java
@@ -53,7 +53,7 @@ public class MainActivity extends AppCompatActivity {
         ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        final FirebaseAppIndex firebaseAppIndex = FirebaseAppIndex.getInstance();
+        final FirebaseAppIndex firebaseAppIndex = FirebaseAppIndex.getInstance(this);
 
         binding.addStickersBtn.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -96,7 +96,7 @@ public class MainActivity extends AppCompatActivity {
                 .setUrl(APP_URI)
                 .build();
 
-        Task<Void> task = FirebaseAppIndex.getInstance().update(articleToIndex);
+        Task<Void> task = FirebaseAppIndex.getInstance(this).update(articleToIndex);
 
         // If the Task is already complete, a call to the listener will be immediately
         // scheduled
@@ -116,7 +116,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
         // log the view action
-        Task<Void> actionTask = FirebaseUserActions.getInstance().start(Actions.newView(TITLE,
+        Task<Void> actionTask = FirebaseUserActions.getInstance(this).start(Actions.newView(TITLE,
                 APP_URI));
 
         actionTask.addOnSuccessListener(MainActivity.this, new OnSuccessListener<Void>() {
@@ -143,7 +143,7 @@ public class MainActivity extends AppCompatActivity {
         final Uri BASE_URL = Uri.parse("https://www.example.com/articles/");
         final String APP_URI = BASE_URL.buildUpon().appendPath(articleId).build().toString();
 
-        Task<Void> actionTask = FirebaseUserActions.getInstance().end(Actions.newView(TITLE,
+        Task<Void> actionTask = FirebaseUserActions.getInstance(this).end(Actions.newView(TITLE,
                 APP_URI));
 
         actionTask.addOnSuccessListener(MainActivity.this, new OnSuccessListener<Void>() {

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/kotlin/AppIndexingService.kt
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/kotlin/AppIndexingService.kt
@@ -7,6 +7,6 @@ import com.google.firebase.appindexing.FirebaseAppIndex
 class AppIndexingService : IntentService("AppIndexingService") {
 
     override fun onHandleIntent(intent: Intent?) {
-        AppIndexingUtil.setStickers(applicationContext, FirebaseAppIndex.getInstance())
+        AppIndexingUtil.setStickers(applicationContext, FirebaseAppIndex.getInstance(applicationContext))
     }
 }

--- a/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/kotlin/MainActivity.kt
+++ b/app-indexing/app/src/main/java/com/google/samples/quickstart/appindexing/kotlin/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val firebaseAppIndex = FirebaseAppIndex.getInstance()
+        val firebaseAppIndex = FirebaseAppIndex.getInstance(this)
 
         with(binding) {
             addStickersBtn.setOnClickListener { startService(Intent(baseContext, AppIndexingService::class.java)) }
@@ -67,7 +67,7 @@ class MainActivity : AppCompatActivity() {
                 .setUrl(appUri)
                 .build()
 
-        val task = FirebaseAppIndex.getInstance().update(articleToIndex)
+        val task = FirebaseAppIndex.getInstance(this).update(articleToIndex)
 
         // If the Task is already complete, a call to the listener will be immediately
         // scheduled
@@ -78,7 +78,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // log the view action
-        val actionTask = FirebaseUserActions.getInstance().start(Actions.newView(TITLE,
+        val actionTask = FirebaseUserActions.getInstance(this).start(Actions.newView(TITLE,
                 appUri))
 
         actionTask.addOnSuccessListener(this) {
@@ -99,7 +99,7 @@ class MainActivity : AppCompatActivity() {
         val baseUrl = Uri.parse("https://www.example.com/kotlin_articles/")
         val appUri = baseUrl.buildUpon().appendPath(articleId).build().toString()
 
-        val actionTask = FirebaseUserActions.getInstance().end(Actions.newView(TITLE,
+        val actionTask = FirebaseUserActions.getInstance(this).end(Actions.newView(TITLE,
                 appUri))
 
         actionTask.addOnSuccessListener(this) {


### PR DESCRIPTION
Staring in [App Indexing 19.2.0](https://firebase.google.com/support/release-notes/android#app-indexing_v19-2-0), `getInstance()` has been deprecated in favor of `getInstance(Context)`.