### PR TITLE
Add examples of custom keys

### DIFF
--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -37,12 +37,10 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
     implementation 'com.google.android.material:material:1.3.0'
+    implementation "androidx.activity:activity-ktx:1.2.2"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:27.1.0')
-
-    // Firebase Crashlytics (Java)
-    implementation 'com.google.firebase:firebase-crashlytics'
 
     // Firebase Crashlytics (Kotlin)
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
@@ -50,6 +48,9 @@ dependencies {
     // For an optimal experience using Crashlytics, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics'
+
+    // For use in the CustomKeySamples -- for testing Google Api Availability.
+    implementation 'com.google.android.gms:play-services-base:17.6.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/crash/app/src/main/AndroidManifest.xml
+++ b/crash/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@ specific language governing permissions and limitations under the License.
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.samples.quickstart.crash">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/crash/app/src/main/java/com/google/samples/quickstart/crash/java/CustomKeySamples.java
+++ b/crash/app/src/main/java/com/google/samples/quickstart/crash/java/CustomKeySamples.java
@@ -1,0 +1,202 @@
+package com.google.samples.quickstart.crash.java;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.pm.InstallSourceInfo;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.Build;
+import android.telephony.TelephonyManager;
+import android.view.View;
+
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.firebase.crashlytics.CustomKeysAndValues;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+import static android.net.NetworkCapabilities.NET_CAPABILITY_NOT_METERED;
+
+/**
+ * The following are samples of custom keys that may be useful to record via Crashlytics prior to a Crash.
+ * <p>
+ * These utility methods are not meant to be comprehensive, but they are illustrative of the types of things you
+ * could track using custom keys in Crashlytics.
+ */
+public class CustomKeySamples {
+
+    /**
+     * Set a subset of custom keys simultaneously.
+     */
+    public static void setSampleCustomKeys(Context context) {
+        FirebaseCrashlytics.getInstance().setCustomKeys(new CustomKeysAndValues.Builder()
+                .putString("Locale", getLocale(context))
+                .putFloat("Screen Density", getDensity(context))
+                .putString("Google Play Services Availability", getGooglePlayServicesAvailability(context))
+                .putString("Os Version", getOsVersion())
+                .putString("Install Source", getInstallSource(context))
+                .putString("Preferred ABI", getPreferredAbi()).build());
+    }
+
+    /**
+     * Update network state and add a hook to update network state going forward.
+     */
+    public static void updateAndTrackNetworkState(Context context) {
+        ConnectivityManager connectivityManager = (ConnectivityManager) context
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            NetworkCapabilities networkCapabilities = connectivityManager
+                    .getNetworkCapabilities(connectivityManager.getActiveNetwork());
+            if (networkCapabilities != null) {
+                updateNetworkCapabilityCustomKeys(networkCapabilities);
+            }
+
+            // Set up a callback to match our best-practices around custom keys being up-to-date
+            connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
+                @Override
+                public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+                    updateNetworkCapabilityCustomKeys(networkCapabilities);
+                }
+            });
+        }
+    }
+
+    private static void updateNetworkCapabilityCustomKeys(NetworkCapabilities networkCapabilities) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            FirebaseCrashlytics instance = FirebaseCrashlytics.getInstance();
+            instance.setCustomKey("Network Bandwidth", networkCapabilities.getLinkDownstreamBandwidthKbps());
+            instance.setCustomKey("Network Upstream", networkCapabilities.getLinkUpstreamBandwidthKbps());
+            instance.setCustomKey("Network Metered", networkCapabilities.hasCapability(NET_CAPABILITY_NOT_METERED));
+            // This key is long and not as easy to filter by.
+            instance.setCustomKey("Network Capabilities", networkCapabilities.toString());
+        }
+    }
+
+    /**
+     * @see {@link com.google.samples.quickstart.crash.java.CustomKeySamples#updateAndTrackNetworkState},
+     * which does not require READ_PHONE_STATE
+     * and returns more useful information about bandwidth, metering, and capabilities.
+     */
+    @Deprecated
+    @SuppressLint("MissingPermission")
+    public static void addPhoneStateRequiredNetworkKeys(Context context) {
+        TelephonyManager telephonyManager = ((TelephonyManager) context
+                .getSystemService(Context.TELEPHONY_SERVICE));
+
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) !=
+                PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        int networkType;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            networkType = telephonyManager.getDataNetworkType();
+        } else {
+            networkType = telephonyManager.getNetworkType();
+        }
+        String simOperatorId = telephonyManager.getSimOperator();
+        FirebaseCrashlytics.getInstance().setCustomKey("Network Type", networkType);
+        FirebaseCrashlytics.getInstance().setCustomKey("Sim Operator", simOperatorId);
+    }
+
+    /**
+     * Retrieve the locale information for the app.
+     */
+    @SuppressWarnings("deprecation")
+    public static String getLocale(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return context
+                    .getResources()
+                    .getConfiguration()
+                    .getLocales().get(0).toString();
+        }
+
+        return context
+                .getResources()
+                .getConfiguration().locale.toString();
+    }
+
+    /**
+     * Retrieve the screen density information for the app.
+     */
+    public static float getDensity(Context context) {
+        return context
+                .getResources()
+                .getDisplayMetrics()
+                .density;
+    }
+
+    /**
+     * Retrieve the locale information for the app.
+     */
+    public static String getGooglePlayServicesAvailability(Context context) {
+        return GoogleApiAvailability
+                .getInstance()
+                .isGooglePlayServicesAvailable(context) == 0 ? "Unavailable" : "Available";
+    }
+
+    /**
+     * Return the underlying kernel version of the Android device.
+     */
+    public static String getOsVersion() {
+        String osVersion = System.getProperty("os.version");
+        return osVersion != null ? osVersion : "Unknown";
+    }
+
+    /**
+     * Retrieve the preferred ABI of the device. Some devices can support
+     * multiple ABIs and the first one returned in the preferred one.
+     */
+    @SuppressWarnings("deprecation")
+    public static String getPreferredAbi() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return Build.SUPPORTED_ABIS[0];
+        }
+
+        return Build.CPU_ABI;
+    }
+
+    /**
+     * Retrieve the install source and return it as a string.
+     **/
+    public static String getInstallSource(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                InstallSourceInfo info = context
+                        .getPackageManager()
+                        .getInstallSourceInfo(context.getPackageName());
+
+                String originating = info.getOriginatingPackageName() == null ? "None" :
+                        info.getOriginatingPackageName();
+                String installing = info.getInstallingPackageName() == null ? "None" : info.getInstallingPackageName();
+                String initiating = info.getInitiatingPackageName() == null ? "None" : info.getInitiatingPackageName();
+
+                // This returns all three of the install source, originating source, and initiating
+                // source.
+                return "Originating: " + originating +
+                        ", Installing: " + installing +
+                        ", Initiating: " + initiating;
+            } catch (PackageManager.NameNotFoundException e) {
+                return "Unknown";
+            }
+        }
+
+        String installerPackageName = context
+                .getPackageManager()
+                .getInstallerPackageName(context.getPackageName());
+
+        return installerPackageName == null ? "None" : installerPackageName;
+    }
+
+    /**
+     * Add a focus listener that updates a custom key when this view gains the focus.
+     **/
+    public static void focusListener(View view, boolean hasFocus) {
+        if (hasFocus) {
+            FirebaseCrashlytics.getInstance().setCustomKey("view_focus", view.getId());
+        }
+    }
+}

--- a/crash/app/src/main/java/com/google/samples/quickstart/crash/java/MainActivity.java
+++ b/crash/app/src/main/java/com/google/samples/quickstart/crash/java/MainActivity.java
@@ -46,6 +46,10 @@ public class MainActivity extends AppCompatActivity {
         final ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+
+        CustomKeySamples.setSampleCustomKeys(this.getApplicationContext());
+        CustomKeySamples.updateAndTrackNetworkState(this.getApplicationContext());
+
         mCrashlytics = FirebaseCrashlytics.getInstance();
 
         // Log the onCreate event, this will also be printed in logcat

--- a/crash/app/src/main/java/com/google/samples/quickstart/crash/kotlin/CustomKeySamples.kt
+++ b/crash/app/src/main/java/com/google/samples/quickstart/crash/kotlin/CustomKeySamples.kt
@@ -1,0 +1,180 @@
+package com.google.samples.quickstart.crash.kotlin
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.telephony.TelephonyManager
+import android.view.View
+import androidx.core.content.ContextCompat
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.crashlytics.ktx.setCustomKeys
+import com.google.firebase.ktx.Firebase
+
+/**
+ * The following are samples of custom keys that may be useful to record via Crashlytics prior to a Crash.
+ *
+ * These utility methods are not meant to be comprehensive, but they are illustrative of the types of things you
+ * could track using custom keys in Crashlytics.
+ */
+class CustomKeySamples(private val context: Context) {
+
+    /**
+     * Set a subset of custom keys simultaneously.
+     */
+    fun setSampleCustomKeys() {
+        Firebase.crashlytics.setCustomKeys {
+            key("Locale", locale)
+            key("Screen Density", density)
+            key("Google Play Services Availability", googlePlayServicesAvailability)
+            key("Os Version", osVersion)
+            key("Install Source", installSource)
+            key("Preferred ABI", preferredAbi)
+        }
+    }
+
+    /**
+     * Update network state and add a hook to update network state going forward.
+     */
+    fun updateAndTrackNetworkState() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            connectivityManager
+                    .getNetworkCapabilities(connectivityManager.activeNetwork)
+                    ?.let { updateNetworkCapabilityCustomKeys(it) }
+
+            // Set up a callback to match our best-practices around custom keys being up-to-date
+            connectivityManager.registerDefaultNetworkCallback(object : NetworkCallback() {
+                override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+                    updateNetworkCapabilityCustomKeys(networkCapabilities)
+                }
+            })
+        }
+    }
+
+    private fun updateNetworkCapabilityCustomKeys(networkCapabilities: NetworkCapabilities) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Firebase.crashlytics.setCustomKeys {
+                key("Network Bandwidth", networkCapabilities.linkDownstreamBandwidthKbps)
+                key("Network Upstream", networkCapabilities.linkUpstreamBandwidthKbps)
+                key("Network Metered", networkCapabilities
+                        .hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED))
+                // This key is long and not as easy to filter by.
+                key("Network Capabilities", networkCapabilities.toString())
+            }
+        }
+    }
+
+    /**
+     * @see {@link com.google.samples.quickstart.crash.java.CustomKeySamples.updateAndTrackNetworkState}, which does not require READ_PHONE_STATE
+     * and returns more useful information about bandwidth, metering, and capabilities.
+     */
+    @Suppress("DEPRECATION")
+    @Deprecated("Prefer updateAndTrackNetworkState, which does not require READ_PHONE_STATE")
+    @SuppressLint("MissingPermission")
+    fun addPhoneStateRequiredNetworkKeys() {
+        val telephonyManager = context
+                .getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+                != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+
+        val networkType: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            telephonyManager.dataNetworkType
+        } else {
+            telephonyManager.networkType
+        }
+
+        Firebase.crashlytics.setCustomKeys {
+            key("Network Type", networkType)
+            key("Sim Operator", telephonyManager.simOperator)
+        }
+    }
+
+    /**
+     * Retrieve the locale information for the app.
+     */
+    @Suppress("DEPRECATION")
+    val locale: String
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context
+                    .resources
+                    .configuration
+                    .locales[0].toString()
+        } else {
+            context
+                    .resources
+                    .configuration.locale.toString()
+        }
+
+    /**
+     * Retrieve the screen density information for the app.
+     */
+    val density: Float
+        get() = context
+                .resources
+                .displayMetrics.density
+
+    /**
+     * Retrieve the locale information for the app.
+     */
+    val googlePlayServicesAvailability: String
+        get() = if (GoogleApiAvailability
+                        .getInstance()
+                        .isGooglePlayServicesAvailable(context) == 0) "Unavailable" else "Available"
+
+    /**
+     * Return the underlying kernel version of the Android device.
+     */
+    val osVersion: String
+        get() = System.getProperty("os.version") ?: "Unknown"
+
+    /**
+     * Retrieve the preferred ABI of the device. Some devices can support
+     * multiple ABIs and the first one returned in the preferred one.
+     */
+    @Suppress("DEPRECATION")
+    val preferredAbi: String
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Build.SUPPORTED_ABIS[0]
+        } else Build.CPU_ABI
+
+    /**
+     * Retrieve the install source and return it as a string.
+     */
+    @Suppress("DEPRECATION")
+    val installSource: String
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                val info = context
+                        .packageManager
+                        .getInstallSourceInfo(context.packageName)
+
+                // This returns all three of the install source, originating source, and initiating
+                // source.
+                "Originating: ${info.originatingPackageName ?: "None"}, " +
+                        "Installing: ${info.installingPackageName ?: "None"}, " +
+                        "Initiating: ${info.initiatingPackageName ?: "None"}"
+            } catch (e: PackageManager.NameNotFoundException) {
+                "Unknown"
+            }
+        } else {
+            context.packageManager.getInstallerPackageName(context.packageName) ?: "None"
+        }
+
+    /**
+     * Add a focus listener that updates a custom key when this view gains the focus.
+     */
+    fun focusListener(view: View, hasFocus: Boolean) {
+        if (hasFocus) {
+            Firebase.crashlytics.setCustomKey("view_focus", view.id)
+        }
+    }
+}

--- a/crash/app/src/main/java/com/google/samples/quickstart/crash/kotlin/MainActivity.kt
+++ b/crash/app/src/main/java/com/google/samples/quickstart/crash/kotlin/MainActivity.kt
@@ -28,6 +28,10 @@ class MainActivity : AppCompatActivity() {
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        val customKeySamples = CustomKeySamples(applicationContext)
+        customKeySamples.setSampleCustomKeys()
+        customKeySamples.updateAndTrackNetworkState()
+
         crashlytics = Firebase.crashlytics
 
         // Log the onCreate event, this will also be printed in logcat


### PR DESCRIPTION
Add a variety of common custom keys stored on Android that can help developers better diagnose their crashes.