### PR TITLE
upgrade to AGP 4.2 and update dependencies

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
 
-    implementation 'com.google.android.gms:play-services-ads:20.0.0'
+    implementation 'com.google.android.gms:play-services-ads:20.1.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:27.1.0')

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/app-indexing/build.gradle
+++ b/app-indexing/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
 
         classpath 'com.google.gms:google-services:4.3.5'
         classpath 'com.google.firebase:perf-plugin:1.3.5'

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
     implementation 'com.google.android.material:material:1.3.0'
-    implementation "androidx.activity:activity-ktx:1.2.2"
+    implementation "androidx.activity:activity-ktx:1.2.3"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:27.1.0')

--- a/crash/build.gradle
+++ b/crash/build.gradle
@@ -7,10 +7,10 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/dynamiclinks/build.gradle
+++ b/dynamiclinks/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.media:media:1.3.0'
+    implementation 'androidx.media:media:1.3.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5'
     }
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -9,8 +9,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/internal/lint/build.gradle
+++ b/internal/lint/build.gradle
@@ -5,10 +5,10 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compileOnly "com.android.tools.lint:lint-api:27.1.3"
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
-    testImplementation "com.android.tools.lint:lint:27.1.3"
-    testImplementation "com.android.tools.lint:lint-tests:27.1.3"
+    compileOnly "com.android.tools.lint:lint-api:27.2.0"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
+    testImplementation "com.android.tools.lint:lint:27.2.0"
+    testImplementation "com.android.tools.lint:lint-tests:27.2.0"
 }
 
 jar {

--- a/internal/lint/build.gradle
+++ b/internal/lint/build.gradle
@@ -1,12 +1,21 @@
 apply plugin: 'java-library'
 apply plugin: "kotlin"
 
-targetCompatibility = JavaVersion.VERSION_1_7
-sourceCompatibility = JavaVersion.VERSION_1_7
+repositories {
+    mavenCentral()
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
 
 dependencies {
     compileOnly "com.android.tools.lint:lint-api:27.2.0"
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     testImplementation "com.android.tools.lint:lint:27.2.0"
     testImplementation "com.android.tools.lint:lint-tests:27.2.0"
 }

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -7,10 +7,10 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.firebase:perf-plugin:1.3.5'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     }
 }
 


### PR DESCRIPTION
I've pulled the changes from #1285 and fixed the build errors by:
- Updating the gradle version (6.5.1 --> 6.7.1)
- Updating our `internal-lint` module to use Java 8.