### PR TITLE
Fix option menu not showing up

### DIFF
--- a/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainFragment.java
+++ b/firestore/app/src/main/java/com/google/firebase/example/fireeats/java/MainFragment.java
@@ -76,6 +76,7 @@ public class MainFragment extends Fragment implements
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        setHasOptionsMenu(true);
         mBinding = FragmentMainBinding.inflate(inflater, container, false);
         return mBinding.getRoot();
     }

--- a/firestore/app/src/main/java/com/google/firebase/example/fireeats/kotlin/MainFragment.kt
+++ b/firestore/app/src/main/java/com/google/firebase/example/fireeats/kotlin/MainFragment.kt
@@ -50,6 +50,7 @@ class MainFragment : Fragment(),
     private lateinit var viewModel: MainActivityViewModel
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        setHasOptionsMenu(true)
         binding = FragmentMainBinding.inflate(inflater, container, false);
         return binding.root;
     }


### PR DESCRIPTION
The option menu was not showing up in the Firestore sample since it got refactored to use Fragments and Navigation.