### PR TITLE
chore(*): disable jetifier

### DIFF
--- a/admob/gradle.properties
+++ b/admob/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/analytics/gradle.properties
+++ b/analytics/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/app-indexing/gradle.properties
+++ b/app-indexing/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
     // Facebook Android SDK (only required for Facebook Login)
     // Used in FacebookLoginActivity.
-    implementation 'com.facebook.android:facebook-login:4.42.0'
+    implementation 'com.facebook.android:facebook-login:8.1.0'
     implementation 'androidx.browser:browser:1.0.0'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginFragment.java
@@ -83,7 +83,7 @@ public class FacebookLoginFragment extends BaseFragment {
         // Initialize Facebook Login button
         mCallbackManager = CallbackManager.Factory.create();
         LoginButton loginButton = mBinding.buttonFacebookLogin;
-        loginButton.setReadPermissions("email", "public_profile");
+        loginButton.setPermissions("email", "public_profile");
         loginButton.registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
             @Override
             public void onSuccess(LoginResult loginResult) {

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginFragment.kt
@@ -51,7 +51,7 @@ class FacebookLoginFragment : BaseFragment() {
         // Initialize Facebook Login button
         callbackManager = CallbackManager.Factory.create()
 
-        binding.buttonFacebookLogin.setReadPermissions("email", "public_profile")
+        binding.buttonFacebookLogin.setPermissions("email", "public_profile")
         binding.buttonFacebookLogin.registerCallback(callbackManager, object : FacebookCallback<LoginResult> {
             override fun onSuccess(loginResult: LoginResult) {
                 Log.d(TAG, "facebook:onSuccess:$loginResult")

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -15,7 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/config/gradle.properties
+++ b/config/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/crash/gradle.properties
+++ b/crash/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/database/gradle.properties
+++ b/database/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/dynamiclinks/gradle.properties
+++ b/dynamiclinks/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
     // Third-party libraries
     implementation 'me.zhanghai.android.materialratingbar:library:1.4.0'
-    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'

--- a/firestore/gradle.properties
+++ b/firestore/gradle.properties
@@ -19,4 +19,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Don't use the gradle build cache since this sample uses experimental SDKs
 android.enableBuildCache=false
 android.useAndroidX=true
-android.enableJetifier=true

--- a/functions/gradle.properties
+++ b/functions/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@ org.gradle.caching=true
 
 ## Play and Firebase moving to AndroidX
 android.useAndroidX=true
-android.enableJetifier=true

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     // FIAM (Kotlin)
     implementation 'com.google.firebase:firebase-inappmessaging-ktx'
     implementation 'com.google.firebase:firebase-inappmessaging-display-ktx'
+    implementation('com.squareup.picasso:picasso') {
+        version { strictly("2.8") }
+        because("Firebase In-App Messaging includes a Picasso version that doesn't use AndroidX")
+    }
 
     // The Firebase SDK for Google Analytics is required to use In-App Messaging
     // Analytics (Java)

--- a/inappmessaging/gradle.properties
+++ b/inappmessaging/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-installations-ktx:17.0.0'
 
-    implementation 'android.arch.work:work-runtime:1.0.1'
+    implementation 'androidx.work:work-runtime:2.5.0'
 
     // Testing dependencies
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/messaging/gradle.properties
+++ b/messaging/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
 
-    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/perf/app/src/main/java/com/google/firebase/quickstart/perfmon/java/MainActivity.java
+++ b/perf/app/src/main/java/com/google/firebase/quickstart/perfmon/java/MainActivity.java
@@ -1,8 +1,10 @@
 package com.google.firebase.quickstart.perfmon.java;
 
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
@@ -10,7 +12,8 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -110,20 +113,16 @@ public class MainActivity extends AppCompatActivity {
         Glide.with(this).
                 load(IMAGE_URL)
                 .placeholder(new ColorDrawable(ContextCompat.getColor(this, R.color.colorAccent)))
-                .listener(new RequestListener<String, GlideDrawable>() {
+                .listener(new RequestListener<Drawable>() {
                     @Override
-                    public boolean onException(
-                            Exception e, String model, Target<GlideDrawable> target,
-                            boolean isFirstResource) {
-                        mNumStartupTasks.countDown(); // Signal end of image load task.
+                    public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                        mNumStartupTasks.countDown();
                         return false;
                     }
 
                     @Override
-                    public boolean onResourceReady(
-                            GlideDrawable resource, String model, Target<GlideDrawable> target,
-                            boolean isFromMemoryCache, boolean isFirstResource) {
-                        mNumStartupTasks.countDown(); // Signal end of image load task.
+                    public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                        mNumStartupTasks.countDown();
                         return false;
                     }
                 }).into(binding.headerIcon);

--- a/perf/app/src/main/java/com/google/firebase/quickstart/perfmon/kotlin/MainActivity.kt
+++ b/perf/app/src/main/java/com/google/firebase/quickstart/perfmon/kotlin/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.google.firebase.quickstart.perfmon.kotlin
 
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AppCompatActivity
@@ -8,7 +9,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.drawable.GlideDrawable
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 import com.google.android.gms.tasks.OnCompleteListener
@@ -85,29 +87,29 @@ class MainActivity : AppCompatActivity() {
 
     private fun loadImageFromWeb() {
         Glide.with(this).load(IMAGE_URL)
-                .placeholder(ColorDrawable(ContextCompat.getColor(this, R.color.colorAccent)))
-                .listener(object : RequestListener<String, GlideDrawable> {
-                    override fun onException(
-                        e: Exception,
-                        model: String,
-                        target: Target<GlideDrawable>,
-                        isFirstResource: Boolean
-                    ): Boolean {
-                        numStartupTasks.countDown() // Signal end of image load task.
-                        return false
-                    }
+            .placeholder(ColorDrawable(ContextCompat.getColor(this, R.color.colorAccent)))
+            .listener(object : RequestListener<Drawable> {
+                override fun onLoadFailed(
+                    e: GlideException?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    numStartupTasks.countDown() // Signal end of image load task.
+                    return false
+                }
 
-                    override fun onResourceReady(
-                        resource: GlideDrawable,
-                        model: String,
-                        target: Target<GlideDrawable>,
-                        isFromMemoryCache: Boolean,
-                        isFirstResource: Boolean
-                    ): Boolean {
-                        numStartupTasks.countDown() // Signal end of image load task.
-                        return false
-                    }
-                }).into(binding.headerIcon)
+                override fun onResourceReady(
+                    resource: Drawable?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    dataSource: DataSource?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    numStartupTasks.countDown() // Signal end of image load task.
+                    return false
+                }
+            }).into(binding.headerIcon)
     }
 
     private fun writeStringToFile(filename: String, content: String): Task<Void> {

--- a/perf/gradle.properties
+++ b/perf/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/storage/gradle.properties
+++ b/storage/gradle.properties
@@ -15,5 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
The main goal of this PR is to disable Jetifier in our project.
In order to make that happen, I also had to:
- upgrade facebook sdk to v8.1.0
- upgrade glide version (4.x)
- update workmanager to v2.5.0
- declare picasso 2.8 explicitly to be used in the FIAM quickstart