### PR TITLE
chore: remove NDK installation from GitHub Actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,8 +13,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8 
-    - name: Install NDK
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Copy mock google_services.json


### PR DESCRIPTION
I believe the main reason why we had the Android NDK on our workflow was for the ML Kit samples to build.
Since these samples are now gone we no longer need the NDK on our CI.