### PR TITLE
refactor(fcm): WorkManager.getInstance() --> WorkManager.getInstance(context)

### DIFF
--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
@@ -130,7 +130,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         // [START dispatch_job]
         OneTimeWorkRequest work = new OneTimeWorkRequest.Builder(MyWorker.class)
                 .build();
-        WorkManager.getInstance().beginWith(work).enqueue();
+        WorkManager.getInstance(this).beginWith(work).enqueue();
         // [END dispatch_job]
     }
 

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
@@ -83,7 +83,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     private fun scheduleJob() {
         // [START dispatch_job]
         val work = OneTimeWorkRequest.Builder(MyWorker::class.java).build()
-        WorkManager.getInstance().beginWith(work).enqueue()
+        WorkManager.getInstance(this).beginWith(work).enqueue()
         // [END dispatch_job]
     }
 


### PR DESCRIPTION
`WorkManager.getInstance()` has been deprecated in favor of `WorkManager.getInstance(context)`