### PR TITLE
refactor(database): migrate to viewpager2

### DIFF
--- a/database/app/src/main/java/com/google/firebase/quickstart/database/java/MainFragment.java
+++ b/database/app/src/main/java/com/google/firebase/quickstart/database/java/MainFragment.java
@@ -11,9 +11,10 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.navigation.fragment.NavHostFragment;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 
+import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.quickstart.database.R;
 import com.google.firebase.quickstart.database.databinding.FragmentMainBinding;
@@ -38,37 +39,35 @@ public class MainFragment extends Fragment {
         setHasOptionsMenu(true);
 
         // Create the adapter that will return a fragment for each section
-        FragmentPagerAdapter mPagerAdapter = new FragmentPagerAdapter(getParentFragmentManager(),
-                FragmentPagerAdapter.BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        FragmentStateAdapter mPagerAdapter = new FragmentStateAdapter(getParentFragmentManager(),
+                getViewLifecycleOwner().getLifecycle()) {
             private final Fragment[] mFragments = new Fragment[]{
                     new RecentPostsFragment(),
                     new MyPostsFragment(),
                     new MyTopPostsFragment(),
             };
-            private final String[] mFragmentNames = new String[]{
-                    getString(R.string.heading_recent),
-                    getString(R.string.heading_my_posts),
-                    getString(R.string.heading_my_top_posts)
-            };
 
+            @NonNull
             @Override
-            public Fragment getItem(int position) {
+            public Fragment createFragment(int position) {
                 return mFragments[position];
             }
 
             @Override
-            public int getCount() {
+            public int getItemCount() {
                 return mFragments.length;
-            }
-
-            @Override
-            public CharSequence getPageTitle(int position) {
-                return mFragmentNames[position];
             }
         };
         // Set up the ViewPager with the sections adapter.
         binding.container.setAdapter(mPagerAdapter);
-        binding.tabs.setupWithViewPager(binding.container);
+        String[] mFragmentNames = new String[]{
+                getString(R.string.heading_recent),
+                getString(R.string.heading_my_posts),
+                getString(R.string.heading_my_top_posts)
+        };
+        new TabLayoutMediator(binding.tabs, binding.container,
+                (tab, position) -> tab.setText(mFragmentNames[position])
+        ).attach();
     }
 
     @Override

--- a/database/app/src/main/java/com/google/firebase/quickstart/database/kotlin/MainFragment.kt
+++ b/database/app/src/main/java/com/google/firebase/quickstart/database/kotlin/MainFragment.kt
@@ -8,8 +8,9 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentPagerAdapter
 import androidx.navigation.fragment.findNavController
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.quickstart.database.R
@@ -22,7 +23,7 @@ class MainFragment : Fragment() {
     private var _binding: FragmentMainBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var pagerAdapter: FragmentPagerAdapter
+    private lateinit var pagerAdapter: FragmentStateAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         _binding = FragmentMainBinding.inflate(inflater, container, false)
@@ -34,28 +35,27 @@ class MainFragment : Fragment() {
         setHasOptionsMenu(true)
 
         // Create the adapter that will return a fragment for each section
-        pagerAdapter = object : FragmentPagerAdapter(parentFragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        pagerAdapter = object : FragmentStateAdapter(parentFragmentManager, viewLifecycleOwner.lifecycle) {
             private val fragments = arrayOf<Fragment>(
                     RecentPostsFragment(),
                     MyPostsFragment(),
                     MyTopPostsFragment())
 
-            private val fragmentNames = arrayOf(
-                    getString(R.string.heading_recent),
-                    getString(R.string.heading_my_posts),
-                    getString(R.string.heading_my_top_posts))
+            override fun createFragment(position: Int) = fragments[position]
 
-            override fun getItem(position: Int) = fragments[position]
-
-            override fun getCount() = fragments.size
-
-            override fun getPageTitle(position: Int) = fragmentNames[position]
+            override fun getItemCount() = fragments.size
         }
 
         // Set up the ViewPager with the sections adapter.
         with(binding) {
             container.adapter = pagerAdapter
-            tabs.setupWithViewPager(container)
+            TabLayoutMediator(tabs, container) { tab, position ->
+                tab.text = when(position) {
+                    0 -> getString(R.string.heading_recent)
+                    1 -> getString(R.string.heading_my_posts)
+                    else -> getString(R.string.heading_my_top_posts)
+                }
+            }.attach()
         }
     }
 

--- a/database/app/src/main/res/layout/fragment_main.xml
+++ b/database/app/src/main/res/layout/fragment_main.xml
@@ -12,7 +12,7 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="0dp"


### PR DESCRIPTION
`FragmentPagerAdapter` from the `ViewPager` class has been deprecated and the [reference docs](https://developer.android.com/reference/androidx/fragment/app/FragmentPagerAdapter) suggests migrating to ViewPager2.

This PR should migrate our database module to not use the deprecated FragmentPagerAdapter.