### PR TITLE
chore(*): replace jcenter() with mavenCentral()

### DIFF
--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -17,6 +17,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,6 +18,6 @@ allprojects {
          //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/app-indexing/build.gradle
+++ b/app-indexing/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,6 +18,6 @@ allprojects {
         // mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,7 +18,7 @@ allprojects {
          //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
     dependencies {
@@ -24,7 +24,7 @@ allprojects {
         google()
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
-        jcenter()
+        mavenCentral()
     }
 
     def isNonStable = { candidate ->

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,6 +18,6 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/crash/build.gradle
+++ b/crash/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -19,7 +19,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,7 +18,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/dynamiclinks/build.gradle
+++ b/dynamiclinks/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,7 +18,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
     dependencies {
@@ -19,7 +19,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,7 +18,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.8'
@@ -18,7 +18,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -18,6 +18,6 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
     dependencies {
@@ -19,7 +19,7 @@ allprojects {
         //mavenLocal() must be listed at the top to facilitate testing
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -17,7 +17,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
`jcenter` has been sunset. This PR should replace it with `mavenCentral` on our project.