### PR TITLE
refactor(auth, functions, firestore, storage): use ActivityResultLauncher

### DIFF
--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation project(':internal:lintchecks')
     implementation 'androidx.multidex:multidex:2.0.1'
 
+    implementation 'androidx.activity:activity-ktx:1.2.3'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'com.google.android.material:material:1.4.0'
@@ -62,7 +63,7 @@ dependencies {
 
     // Firebase UI
     // Used in FirebaseUIActivity.
-    implementation 'com.firebaseui:firebase-ui-auth:7.1.1'
+    implementation 'com.firebaseui:firebase-ui-auth:7.2.0'
 
     // Facebook Android SDK (only required for Facebook Login)
     // Used in FacebookLoginActivity.

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -62,9 +62,10 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:19.0.0'
 
     // FirebaseUI (for authentication)
-    implementation 'com.firebaseui:firebase-ui-auth:7.1.1'
+    implementation 'com.firebaseui:firebase-ui-auth:7.2.0'
 
     // Support Libs
+    implementation 'androidx.activity:activity-ktx:1.2.3'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
+    implementation 'androidx.activity:activity-ktx:1.2.3'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.4.0'
 
@@ -59,7 +60,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging'
 
     // Firebase UI
-    implementation 'com.firebaseui:firebase-ui-auth:7.1.1'
+    implementation 'com.firebaseui:firebase-ui-auth:7.2.0'
     
     // Google Play services
     implementation 'com.google.android.gms:play-services-auth:19.0.0'

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     // Firebase Authentication (Kotlin)
     implementation 'com.google.firebase:firebase-auth-ktx'
 
+    implementation 'androidx.activity:activity-ktx:1.2.3'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'

--- a/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/quickstart/firebasestorage/kotlin/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.google.firebase.quickstart.firebasestorage.kotlin
 
-import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -10,7 +9,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -120,24 +119,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         out.putParcelable(KEY_DOWNLOAD_URL, downloadUrl)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        Log.d(TAG, "onActivityResult:$requestCode:$resultCode:$data")
-        if (requestCode == RC_TAKE_PICTURE) {
-            if (resultCode == Activity.RESULT_OK) {
-                fileUri = data?.data
-
-                if (fileUri != null) {
-                    uploadFromUri(fileUri!!)
-                } else {
-                    Log.w(TAG, "File URI is null")
-                }
-            } else {
-                Toast.makeText(this, "Taking picture failed.", Toast.LENGTH_SHORT).show()
-            }
-        }
-    }
-
     private fun uploadFromUri(uploadUri: Uri) {
         Log.d(TAG, "uploadFromUri:src: $uploadUri")
 
@@ -178,9 +159,14 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         Log.d(TAG, "launchCamera")
 
         // Pick an image from storage
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
-        intent.type = "image/*"
-        startActivityForResult(intent, RC_TAKE_PICTURE)
+        val intentLauncher = registerForActivityResult(ActivityResultContracts.OpenDocument()) { fileUri ->
+            if (fileUri != null) {
+                uploadFromUri(fileUri)
+            } else {
+                Log.w(TAG, "File URI is null")
+            }
+        }
+        intentLauncher.launch(arrayOf("image/*"))
     }
 
     private fun signInAnonymously() {
@@ -278,8 +264,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
     companion object {
 
         private const val TAG = "Storage#MainActivity"
-
-        private const val RC_TAKE_PICTURE = 101
 
         private const val KEY_FILE_URI = "key_file_uri"
         private const val KEY_DOWNLOAD_URL = "key_download_url"


### PR DESCRIPTION
This PR should update `firebase-ui-auth` to `7.2.0` in order to use the new `ActivityResultLauncher` API instead of the deprecated `startActivityForResult()`.