### PR TITLE
Fix launch FirebaseAuthUIActivity crash java and kotlin code

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FirebaseUIFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FirebaseUIFragment.java
@@ -36,6 +36,13 @@ public class FirebaseUIFragment extends Fragment {
 
     private FragmentFirebaseUiBinding mBinding;
 
+    // Build FirebaseUI sign in intent. For documentation on this operation and all
+    // possible customization see: https://github.com/firebase/firebaseui-android
+    private final ActivityResultLauncher<Intent> signInLauncher = registerForActivityResult(
+            new FirebaseAuthUIActivityResultContract(),
+            this::onSignInResult
+    );
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -88,13 +95,6 @@ public class FirebaseUIFragment extends Fragment {
     }
 
     private void startSignIn() {
-        // Build FirebaseUI sign in intent. For documentation on this operation and all
-        // possible customization see: https://github.com/firebase/firebaseui-android
-        ActivityResultLauncher<Intent> signinLauncher = requireActivity()
-                .registerForActivityResult(new FirebaseAuthUIActivityResultContract(),
-                        this::onSignInResult
-                );
-
         Intent intent = AuthUI.getInstance().createSignInIntentBuilder()
                 .setIsSmartLockEnabled(!BuildConfig.DEBUG)
                 .setAvailableProviders(Collections.singletonList(
@@ -102,7 +102,7 @@ public class FirebaseUIFragment extends Fragment {
                 .setLogo(R.mipmap.ic_launcher)
                 .build();
 
-        signinLauncher.launch(intent);
+        signInLauncher.launch(intent);
     }
 
     private void updateUI(FirebaseUser user) {

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FirebaseUIFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FirebaseUIFragment.kt
@@ -32,6 +32,12 @@ class FirebaseUIFragment : Fragment() {
     private val binding: FragmentFirebaseUiBinding
         get() = _binding!!
 
+    // Build FirebaseUI sign in intent. For documentation on this operation and all
+    // possible customization see: https://github.com/firebase/firebaseui-android
+    private val signInLauncher = registerForActivityResult(
+        FirebaseAuthUIActivityResultContract()
+    ) { result -> this.onSignInResult(result)}
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFirebaseUiBinding.inflate(inflater, container, false)
         return binding.root
@@ -64,11 +70,6 @@ class FirebaseUIFragment : Fragment() {
     }
 
     private fun startSignIn() {
-        // Build FirebaseUI sign in intent. For documentation on this operation and all
-        // possible customization see: https://github.com/firebase/firebaseui-android
-        val signInLauncher = requireActivity().registerForActivityResult(
-            FirebaseAuthUIActivityResultContract()
-        ) { result -> this.onSignInResult(result)}
         val intent = AuthUI.getInstance().createSignInIntentBuilder()
                 .setIsSmartLockEnabled(!BuildConfig.DEBUG)
                 .setAvailableProviders(listOf(AuthUI.IdpConfig.EmailBuilder().build()))


### PR DESCRIPTION
Fragments must call registerForActivityResult() before they are created. Use registerForActivityResult() fragment version instead of calling   requireActivity().registerForActivityResult()