### PR TITLE
Demo always sending token to server

### DIFF
--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -58,6 +58,12 @@ dependencies {
     // Firebase Cloud Messaging (Kotlin)
     implementation 'com.google.firebase:firebase-messaging-ktx'
 
+    // Cloud Functions for Firebase (Java)
+    implementation 'com.google.firebase:firebase-functions'
+
+    // Cloud Functions for Firebase (Kotlin)
+    implementation 'com.google.firebase:firebase-functions-ktx'
+
     // For an optimal experience using FCM, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics'


### PR DESCRIPTION
Developers should regularly send their FCM registration token to their corresponding server. This way the server can determine the freshness or staleness of a particular token and decide whether or not to send messages to that token.

This snippet demonstrates sending the FCM registration token to a callable function that will store it appropriately.