### PR TITLE
refactor(database): add proguard rule to keep kotlin models in release build

### DIFF
--- a/database/app/proguard-rules.pro
+++ b/database/app/proguard-rules.pro
@@ -28,3 +28,7 @@
 -keepclassmembers class com.google.firebase.quickstart.database.java.models.** {
     *;
 }
+
+-keepclassmembers class com.google.firebase.quickstart.database.kotlin.models.** {
+    *;
+}


### PR DESCRIPTION
Fixes (partially) #1355 

Running the `release` variant of our database quickstart crashes right after auth, due to missing kotlin model classes.
I can see in our `proguard-rules.pro` file that we have a rule to keep the java models, but it seems like we forgot to also add a rule to keep the kotlin models when we created them in #654
