### PR TITLE
update gradle-versions-plugin to 0.41.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.ben-manes.versions' version '0.27.0'
+    id 'com.github.ben-manes.versions' version '0.41.0'
 }
 
 allprojects {


### PR DESCRIPTION
After the update to AGP 7, running the `dependencyUpdates` gradle task with the current version of the `gradle-versions-plugin` fails with an error. This is causing @dpebot to not update the dependency versions in this repository.

This PR should update the `gradle-versions-plugin` to the latest version (0.41.0) so that we can bring back our friendly Repository Gardener.

---

Full error stacktrace for reference:

```
> Task :dependencyUpdates FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':dependencyUpdates' (type 'DependencyUpdatesTask').
  - Type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'checkConstraints' has redundant getters: 'getCheckConstraints()' and 'isCheckConstraints()'.
    
    Reason: Boolean property 'checkConstraints' has both an `is` and a `get` getter.
    
    Possible solutions:
      1. Remove one of the getters.
      2. Annotate one of the getters with @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#redundant_getters for more details about this problem.
  - Type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'checkForGradleUpdate' has redundant getters: 'getCheckForGradleUpdate()' and 'isCheckForGradleUpdate()'.
    
    Reason: Boolean property 'checkForGradleUpdate' has both an `is` and a `get` getter.
    
    Possible solutions:
      1. Remove one of the getters.
      2. Annotate one of the getters with @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#redundant_getters for more details about this problem.
  - Type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'outputFormatter' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask' property 'resolutionStrategy' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/7.0.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 5s
1 actionable task: 1 executed
```