### PR TITLE
Auto-update dependencies

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.samples.quickstart.admobexample"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -41,13 +41,13 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
 
-    implementation 'com.google.android.gms:play-services-ads:20.2.0'
+    implementation 'com.google.android.gms:play-services-ads:20.6.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -56,7 +56,7 @@ dependencies {
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics'
 
-    debugImplementation "androidx.fragment:fragment-testing:1.3.6"
+    debugImplementation "androidx.fragment:fragment-testing:1.4.1"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/admob/app/src/main/AndroidManifest.xml
+++ b/admob/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
 
         <activity
             android:name=".EntryChoiceActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.analytics"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -34,9 +34,9 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "androidx.preference:preference-ktx:1.1.1"
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation "androidx.preference:preference-ktx:1.2.0"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')

--- a/analytics/app/src/main/AndroidManifest.xml
+++ b/analytics/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
 
         <activity
             android:name="com.google.firebase.quickstart.analytics.EntryChoiceActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/appdistribution/app/build.gradle
+++ b/appdistribution/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.google.firebase.appdistributionquickstart"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -37,12 +37,12 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:29.0.0')
+    implementation platform('com.google.firebase:firebase-bom:29.3.1')
 
     // ADD the SDK to the "prerelease" variant only (example)
     implementation 'com.google.firebase:firebase-appdistribution-ktx:16.0.0-beta01'

--- a/appdistribution/app/src/main/AndroidManifest.xml
+++ b/appdistribution/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
             android:theme="@style/AppTheme">
         </activity>
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/appdistribution/build.gradle
+++ b/appdistribution/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.8'
+        classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -7,13 +7,13 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     flavorDimensions "minSdkVersion"
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.auth"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -42,12 +42,12 @@ dependencies {
     implementation project(':internal:lintchecks')
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation 'androidx.activity:activity-ktx:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -59,11 +59,11 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx'
 
     // Google Sign In SDK (only required for Google Sign In)
-    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-auth:20.1.0'
 
     // Firebase UI
     // Used in FirebaseUIActivity.
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:8.0.1'
 
     // Facebook Android SDK (only required for Facebook Login)
     // Used in FacebookLoginActivity.

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -26,7 +27,8 @@
         <activity
             android:name=".java.PasswordlessActivity"
             android:label="@string/label_passwordless"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data
@@ -40,7 +42,8 @@
         <activity
             android:name=".kotlin.PasswordlessActivity"
             android:label="@string/label_passwordless"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,13 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
 
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.google.firebase:perf-plugin:1.4.1'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2'
     }
 }
 

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.samples.quickstart.config"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -35,7 +35,7 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')

--- a/config/app/src/main/AndroidManifest.xml
+++ b/config/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 
         <activity
             android:name=".EntryChoiceActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -8,12 +8,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.samples.quickstart.crash"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -39,8 +39,8 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation "androidx.activity:activity-ktx:1.3.0"
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation "androidx.activity:activity-ktx:1.4.0"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -53,7 +53,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
 
     // For use in the CustomKeySamples -- for testing Google Api Availability.
-    implementation 'com.google.android.gms:play-services-base:17.6.0'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/crash/app/src/main/AndroidManifest.xml
+++ b/crash/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@ specific language governing permissions and limitations under the License.
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/crash/build.gradle
+++ b/crash/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.database"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -36,11 +36,11 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -57,7 +57,7 @@ dependencies {
     // Firebase Authentication (Kotlin)
     implementation 'com.google.firebase:firebase-auth-ktx'
 
-    implementation 'com.firebaseui:firebase-ui-database:8.0.0'
+    implementation 'com.firebaseui:firebase-ui-database:8.0.1'
 
     // Needed to fix a dependency conflict with FirebaseUI'
     implementation 'androidx.arch.core:core-runtime:2.1.0'

--- a/database/app/src/main/AndroidManifest.xml
+++ b/database/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/dynamiclinks/app/build.gradle
+++ b/dynamiclinks/app/build.gradle
@@ -7,13 +7,13 @@ plugins {
 check.dependsOn 'assembleMainFlavorDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     flavorDimensions "irrelevant"
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.deeplinks"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -48,10 +48,10 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:29.0.0')
+    implementation platform('com.google.firebase:firebase-bom:29.3.1')
 
     // Firebase Dynamic Links (Java)
     implementation 'com.google.firebase:firebase-dynamic-links'

--- a/dynamiclinks/app/src/main/AndroidManifest.xml
+++ b/dynamiclinks/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme" >
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -17,7 +18,8 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".java.MainActivity" >
+        <activity android:name=".java.MainActivity"
+            android:exported="true">
             <!-- [START link_intent_filter] -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
@@ -30,7 +32,8 @@
             <!-- [END link_intent_filter] -->
         </activity>
 
-        <activity android:name=".kotlin.MainActivity" >
+        <activity android:name=".kotlin.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/dynamiclinks/build.gradle
+++ b/dynamiclinks/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     testBuildType "release"
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.firebase.example.fireeats"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -59,29 +59,29 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx'
 
     // Google Play services
-    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-auth:20.1.0'
 
     // FirebaseUI (for authentication)
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:8.0.1'
 
     // Support Libs
-    implementation 'androidx.activity:activity-ktx:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.media:media:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.media:media:1.6.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
 
     // Android architecture components
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.3.1'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.4.1'
 
     // Third-party libraries
     implementation 'me.zhanghai.android.materialratingbar:library:1.4.0'

--- a/firestore/app/src/main/AndroidManifest.xml
+++ b/firestore/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
 
         <activity android:name=".EntryChoiceActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.EntryChoice">
+            android:theme="@style/AppTheme.EntryChoice"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5'
     }
 }

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 android {
     // Changes the test build type for instrumented tests to "stage".
     testBuildType "release"
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.samples.quickstart.functions"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -37,9 +37,9 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'androidx.activity:activity-ktx:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -60,10 +60,10 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging'
 
     // Firebase UI
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:8.0.1'
     
     // Google Play services
-    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+    implementation 'com.google.android.gms:play-services-auth:20.1.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/functions/app/src/main/AndroidManifest.xml
+++ b/functions/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@ specific language governing permissions and limitations under the License.
         <activity android:name=".java.MainActivity"/>
         <activity android:name=".kotlin.MainActivity"/>
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.google.firebase.fiamquickstart"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -37,12 +37,12 @@ dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
 
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:29.0.0')
+    implementation platform('com.google.firebase:firebase-bom:29.3.1')
 
     // FIAM (Java)
     implementation 'com.google.firebase:firebase-inappmessaging-display'
@@ -57,7 +57,7 @@ dependencies {
     // Analytics (Kotlin)
     implementation 'com.google.firebase:firebase-analytics-ktx'
 
-    implementation 'com.google.firebase:firebase-installations-ktx:17.0.0'
+    implementation 'com.google.firebase:firebase-installations-ktx:17.0.1'
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/inappmessaging/app/src/main/AndroidManifest.xml
+++ b/inappmessaging/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
             android:theme="@style/AppTheme">
         </activity>
 
-        <activity android:name="com.google.firebase.fiamquickstart.EntryChoiceActivity">
+        <activity android:name="com.google.firebase.fiamquickstart.EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.8'
+        classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/internal/chooserx/build.gradle
+++ b/internal/chooserx/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.material:material:1.4.0'
+    api 'com.google.android.material:material:1.5.0'
     api 'androidx.recyclerview:recyclerview:1.2.1'
-    api 'androidx.constraintlayout:constraintlayout:2.1.0'
+    api 'androidx.constraintlayout:constraintlayout:2.1.3'
 }

--- a/internal/lint/build.gradle
+++ b/internal/lint/build.gradle
@@ -17,9 +17,9 @@ compileKotlin {
 }
 
 dependencies {
-    compileOnly "com.android.tools.lint:lint-api:30.0.0"
-    testImplementation "com.android.tools.lint:lint:30.0.0"
-    testImplementation "com.android.tools.lint:lint-tests:30.0.0"
+    compileOnly "com.android.tools.lint:lint-api:30.1.3"
+    testImplementation "com.android.tools.lint:lint:30.1.3"
+    testImplementation "com.android.tools.lint:lint-tests:30.1.3"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/internal/lintchecks/build.gradle
+++ b/internal/lintchecks/build.gradle
@@ -2,11 +2,11 @@ plugins {
     id 'com.android.library'
 }
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
     }
 }
 

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.fcm"
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -44,11 +44,11 @@ android {
 dependencies {
     implementation project(":internal:lintchecks")
     implementation project(":internal:chooserx")
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'androidx.core:core:1.6.0'
+    implementation 'androidx.core:core:1.7.0'
 
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:28.3.0')
@@ -63,13 +63,13 @@ dependencies {
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics'
 
-    implementation 'com.google.firebase:firebase-installations-ktx:17.0.0'
+    implementation 'com.google.firebase:firebase-installations-ktx:17.0.1'
 
-    implementation 'androidx.work:work-runtime:2.5.0'
+    implementation 'androidx.work:work-runtime:2.7.1'
 
     // Testing dependencies
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.annotation:annotation:1.2.0'
+    androidTestImplementation 'androidx.annotation:annotation:1.3.0'
 }

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         <!-- [END fcm_default_channel] -->
         <activity
             android:name=".EntryChoiceActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -8,11 +8,11 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.google.firebase.quickstart.perfmon"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -50,9 +50,9 @@ dependencies {
     // Firebase Performance Monitoring (Kotlin)
     implementation 'com.google.firebase:firebase-perf-ktx'
 
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
 
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 

--- a/perf/app/src/main/AndroidManifest.xml
+++ b/perf/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
 
         <activity android:name=".kotlin.MainActivity"/>
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.firebase:perf-plugin:1.4.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.firebase:perf-plugin:1.4.1'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 include ':admob:app',
         ':analytics:app',
         ':appdistribution:app',
-        ':app-indexing:app',
         ':auth:app',
         ':config:app',
         ':crash:app',

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.firebasestorage"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -49,9 +49,9 @@ dependencies {
     // Firebase Authentication (Kotlin)
     implementation 'com.google.firebase:firebase-auth-ktx'
 
-    implementation 'androidx.activity:activity-ktx:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.google.android.material:material:1.5.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion 32
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 

--- a/storage/app/src/main/AndroidManifest.xml
+++ b/storage/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".EntryChoiceActivity">
+        <activity android:name=".EntryChoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
 }
 


### PR DESCRIPTION
~I'm not sure why the bot didn't open this PR himself, but if it happens again we'll have to investigate further.~
**Update:** I figured it out. Seems like there was an existing ghost PR similar to what happened in #1253. The solution was to delete the branch and push it again. Weird

I took the opportunity to add some fixes for the build:
- add missing `export` attribute on some activities with intent filters;
- remove the `app-indexing` module from the build config;
- enable multidex for the storage quickstart (build was [failing](https://github.com/firebase/quickstart-android/runs/6096131885?check_suite_focus=true)).