### PR TITLE
update facebook sdk to version 13.2.0

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -24,7 +24,7 @@ Getting Started
 
 ### Facebook Login Setup
 
-- Go to the [Meta for Developers](https://developers.facebook.com) and follow all
+- Go to the [Meta for Developers Site](https://developers.facebook.com) and follow all
   instructions to set up a new Android app.
   - When asked for a package name, use
   `com.google.firebase.quickstart.auth`.

--- a/auth/README.md
+++ b/auth/README.md
@@ -34,7 +34,7 @@ Getting Started
   - Select the **Auth** panel and then click the **Sign In Method** tab.
   - Click **Facebook** and turn on the **Enable** switch, then click **Save**.
   - Enter your Facebook **App Id** and **App Secret** and click **Save**.
-- Open the file `app/src/main/res/values/ids.xml` and replace the value of the `facebook_app_id` with the ID of the Facebook app you just created.
+- Open the file `app/src/main/res/values/ids.xml` and replace the values of `facebook_app_id` and `facebook_client_token` with the ID of the Facebook app you just created and the client token respectively.
 - Run the app on your device or emulator.
     - Select the **FacebookLoginFragment** from the main screen.
     - Click the **Sign In** button to begin.

--- a/auth/README.md
+++ b/auth/README.md
@@ -24,19 +24,19 @@ Getting Started
 
 ### Facebook Login Setup
 
-- Go to the [Facebook Developers Site](https://developers.facebook.com) and follow all
+- Go to the [Meta for Developers](https://developers.facebook.com) and follow all
   instructions to set up a new Android app.
   - When asked for a package name, use
-  `com.google.firebase.quickstart.usermanagement`.
+  `com.google.firebase.quickstart.auth`.
   - When asked for a main class name,
-  use `com.google.firebase.quickstart.usermanagement.FacebookLoginActivity`.
+  use `com.google.firebase.quickstart.auth.kotlin.MainActivity`.
 - Go to the [Firebase Console][fir-console] and navigate to your project:
   - Select the **Auth** panel and then click the **Sign In Method** tab.
   - Click **Facebook** and turn on the **Enable** switch, then click **Save**.
   - Enter your Facebook **App Id** and **App Secret** and click **Save**.
 - Open the file `app/src/main/res/values/ids.xml` and replace the value of the `facebook_app_id` with the ID of the Facebook app you just created.
 - Run the app on your device or emulator.
-    - Select the **FacebookLoginActivity** from the main screen.
+    - Select the **FacebookLoginFragment** from the main screen.
     - Click the **Sign In** button to begin.
     - If you see text that says Facebook is disabled, make sure you are running
       either the **facebookDebug** or **facebookRelease** variants of this sample.

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     // Facebook Android SDK (only required for Facebook Login)
     // Used in FacebookLoginActivity.
-    implementation 'com.facebook.android:facebook-login:8.1.0'
+    implementation 'com.facebook.android:facebook-login:13.0.0'
     implementation 'androidx.browser:browser:1.0.0'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     // Facebook Android SDK (only required for Facebook Login)
     // Used in FacebookLoginActivity.
-    implementation 'com.facebook.android:facebook-login:13.0.0'
+    implementation 'com.facebook.android:facebook-login:13.2.0'
     implementation 'androidx.browser:browser:1.0.0'
 
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -61,6 +61,8 @@
             android:value="@string/facebook_app_id"
             tools:replace="android:value" />
 
+        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
+
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/FacebookLoginFragment.java
@@ -16,7 +16,6 @@
 
 package com.google.firebase.quickstart.auth.java;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -111,14 +110,6 @@ public class FacebookLoginFragment extends BaseFragment {
         // Check if user is signed in (non-null) and update UI accordingly.
         FirebaseUser currentUser = mAuth.getCurrentUser();
         updateUI(currentUser);
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-        // Pass the activity result back to the Facebook SDK
-        mCallbackManager.onActivityResult(requestCode, resultCode, data);
     }
 
     private void handleFacebookAccessToken(AccessToken token) {

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/FacebookLoginFragment.kt
@@ -1,6 +1,5 @@
 package com.google.firebase.quickstart.auth.kotlin
 
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -75,13 +74,6 @@ class FacebookLoginFragment : BaseFragment() {
         // Check if user is signed in (non-null) and update UI accordingly.
         val currentUser = auth.currentUser
         updateUI(currentUser)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        // Pass the activity result back to the Facebook SDK
-        callbackManager.onActivityResult(requestCode, resultCode, data)
     }
 
     private fun handleFacebookAccessToken(token: AccessToken) {

--- a/auth/app/src/main/res/values/ids.xml
+++ b/auth/app/src/main/res/values/ids.xml
@@ -6,4 +6,5 @@
     -->
     <!--  TODO(developer): REPLACE -->
     <string name="facebook_app_id">REPLACE_ME</string>
+    <string name="facebook_client_token">REPLACE_ME</string>
 </resources>


### PR DESCRIPTION
The Facebook Android SDK has been updated and the previous versions no longer work.
This PR should:
- update the facebook sdk version on our project
- remove the deprecated `onActivityResult` method
- update the README.md