### PR TITLE
Replace Google Sign In with Google Identity Services

### DIFF
--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     // Firebase Authentication (Kotlin)
     implementation 'com.google.firebase:firebase-auth-ktx'
 
-    // Google Sign In SDK (only required for Google Sign In)
+    // Google Identity Services SDK (only required for Auth with Google)
     implementation 'com.google.android.gms:play-services-auth:20.2.0'
 
     // Firebase UI

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInFragment.java
@@ -99,12 +99,6 @@ public class GoogleSignInFragment extends BaseFragment {
                 signOut();
             }
         });
-        mBinding.disconnectButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                revokeAccess();
-            }
-        });
 
         // Configure Google Sign In
         signInClient = Identity.getSignInClient(requireContext());
@@ -238,14 +232,6 @@ public class GoogleSignInFragment extends BaseFragment {
                 });
     }
 
-    private void revokeAccess() {
-        // Firebase sign out
-        mAuth.signOut();
-
-        // Google revoke access
-        // TODO(rosariopf): Find out how to revoke access with GIS
-    }
-
     private void updateUI(FirebaseUser user) {
         hideProgressBar();
         if (user != null) {
@@ -253,13 +239,13 @@ public class GoogleSignInFragment extends BaseFragment {
             mBinding.detail.setText(getString(R.string.firebase_status_fmt, user.getUid()));
 
             mBinding.signInButton.setVisibility(View.GONE);
-            mBinding.signOutAndDisconnect.setVisibility(View.VISIBLE);
+            mBinding.signOutButton.setVisibility(View.VISIBLE);
         } else {
             mBinding.status.setText(R.string.signed_out);
             mBinding.detail.setText(null);
 
             mBinding.signInButton.setVisibility(View.VISIBLE);
-            mBinding.signOutAndDisconnect.setVisibility(View.GONE);
+            mBinding.signOutButton.setVisibility(View.GONE);
         }
     }
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/GoogleSignInFragment.java
@@ -121,7 +121,7 @@ public class GoogleSignInFragment extends BaseFragment {
         updateUI(currentUser);
     }
 
-    public void handleSignInResult(Intent data) {
+    private void handleSignInResult(Intent data) {
         try {
             // Google Sign In was successful, authenticate with Firebase
             SignInCredential credential = signInClient.getSignInCredentialFromIntent(data);

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -54,7 +54,6 @@ class GoogleSignInFragment : BaseFragment() {
         // Button listeners
         binding.signInButton.setOnClickListener { signIn() }
         binding.signOutButton.setOnClickListener { signOut() }
-        binding.disconnectButton.setOnClickListener { revokeAccess() }
 
         // Configure Google Sign In
         signInClient = Identity.getSignInClient(requireContext())
@@ -175,17 +174,6 @@ class GoogleSignInFragment : BaseFragment() {
         }
     }
 
-    private fun revokeAccess() {
-        // Firebase sign out
-        auth.signOut()
-
-        // Google revoke access
-        // TODO(rosariopf): Find out how to revoke access with GIS
-//        googleSignInClient.revokeAccess().addOnCompleteListener(requireActivity()) {
-//            updateUI(null)
-//        }
-    }
-
     private fun updateUI(user: FirebaseUser?) {
         hideProgressBar()
         if (user != null) {
@@ -193,13 +181,13 @@ class GoogleSignInFragment : BaseFragment() {
             binding.detail.text = getString(R.string.firebase_status_fmt, user.uid)
 
             binding.signInButton.visibility = View.GONE
-            binding.signOutAndDisconnect.visibility = View.VISIBLE
+            binding.signOutButton.visibility = View.VISIBLE
         } else {
             binding.status.setText(R.string.signed_out)
             binding.detail.text = null
 
             binding.signInButton.visibility = View.VISIBLE
-            binding.signOutAndDisconnect.visibility = View.GONE
+            binding.signOutButton.visibility = View.GONE
         }
     }
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -161,7 +161,7 @@ class GoogleSignInFragment : BaseFragment() {
                 .build()
             signInLauncher.launch(intentSenderRequest)
         } catch (e: IntentSender.SendIntentException) {
-            Log.e(TAG, "Couldn't start One Tap UI: ${e.localizedMessage}")
+            Log.e(TAG, "Couldn't start Sign In: ${e.localizedMessage}")
         }
     }
 
@@ -209,6 +209,6 @@ class GoogleSignInFragment : BaseFragment() {
     }
 
     companion object {
-        private const val TAG = "GoogleSignInFrag"
+        private const val TAG = "GoogleFragmentKt"
     }
 }

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -9,7 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.SignInClient
@@ -36,7 +36,7 @@ class GoogleSignInFragment : BaseFragment() {
     private lateinit var oneTapClient: SignInClient
     private lateinit var signInRequest: BeginSignInRequest
 
-    private val signInLauncher = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+    private val signInLauncher = registerForActivityResult(StartIntentSenderForResult()) { result ->
         handleSignInResult(result.data)
     }
 

--- a/auth/app/src/main/res/layout/fragment_google.xml
+++ b/auth/app/src/main/res/layout/fragment_google.xml
@@ -58,13 +58,6 @@
         android:paddingTop="16dp"
         android:background="@color/grey_300">
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintGuide_percent="0.5" />
-
         <com.google.android.gms.common.SignInButton
             android:id="@+id/signInButton"
             android:layout_width="wrap_content"
@@ -78,39 +71,13 @@
 
         <Button
             android:id="@+id/signOutButton"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/sign_out"
             android:theme="@style/ThemeOverlay.MyDarkButton"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginRight="8dp"
-            app:layout_constraintEnd_toStartOf="@+id/guideline"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/signInButton" />
-
-        <Button
-            android:id="@+id/disconnectButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/disconnect"
-            android:theme="@style/ThemeOverlay.MyDarkButton"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/guideline"
-            app:layout_constraintTop_toBottomOf="@+id/signInButton" />
-
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/signOutAndDisconnect"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            tools:visibility="visible"
-            app:constraint_referenced_ids="disconnectButton, signOutButton"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/auth/app/src/main/res/values/strings.xml
+++ b/auth/app/src/main/res/values/strings.xml
@@ -43,7 +43,6 @@
     <string name="send_link">Send Link</string>
     <string name="sign_out">Sign Out</string>
     <string name="verify_email">Verify</string>
-    <string name="disconnect">Disconnect</string>
     <string name="loading">Loading…</string>
     <string name="custom_token">Custom Token</string>
     <string name="signed_in">Signed In</string>


### PR DESCRIPTION
This PR should:
- Use the new ActivityResultContracts API on Firebase Auth with Google
- Migrate from Google Sign-in to Google Identity Services

TODO:
- [x] ~Find out if Google Identity Services supports revoking a user's access.~
    **Update:** GIS team confirmed this feature was intentionally left out. This PR removes the revoke access button.