### PR TITLE
FCM updates for API levels 31 and 33

### DIFF
--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(":internal:chooserx")
 
     implementation 'androidx.activity:activity-ktx:1.5.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.2'
     implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'com.google.android.material:material:1.6.1'
 

--- a/functions/app/src/main/java/com/google/samples/quickstart/functions/java/MainActivity.java
+++ b/functions/app/src/main/java/com/google/samples/quickstart/functions/java/MainActivity.java
@@ -16,11 +16,15 @@
 
 package com.google.samples.quickstart.functions.java;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract;
@@ -28,11 +32,13 @@ import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.Toast;
 
 import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.IdpResponse;
@@ -66,6 +72,18 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private FirebaseFunctions mFunctions;
     // [END define_functions_instance]
 
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    Toast.makeText(this, "Notifications permission granted", Toast.LENGTH_SHORT)
+                            .show();
+                } else {
+                    Toast.makeText(this,
+                            "FCM can't post notifications without POST_NOTIFICATIONS permission",
+                            Toast.LENGTH_LONG).show();
+                }
+            });
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -79,6 +97,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // [START initialize_functions_instance]
         mFunctions = FirebaseFunctions.getInstance();
         // [END initialize_functions_instance]
+
+        askNotificationPermission();
     }
 
     // [START function_add_numbers]
@@ -272,6 +292,19 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             case R.id.buttonSignIn:
                 onSignInClicked();
                 break;
+        }
+    }
+
+    private void askNotificationPermission() {
+        // This is only necessary for API level >= 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                    PackageManager.PERMISSION_GRANTED) {
+                // FCM SDK (and your app) can post notifications.
+            } else{
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+            }
         }
     }
 }

--- a/functions/app/src/main/java/com/google/samples/quickstart/functions/kotlin/MainActivity.kt
+++ b/functions/app/src/main/java/com/google/samples/quickstart/functions/kotlin/MainActivity.kt
@@ -1,13 +1,19 @@
 package com.google.samples.quickstart.functions.kotlin
 
+import android.Manifest
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
 import android.util.Log
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
 import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
@@ -36,6 +42,18 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
 
     private lateinit var binding: ActivityMainBinding
 
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            Toast.makeText(this, "Notifications permission granted",Toast.LENGTH_SHORT)
+                .show()
+        } else {
+            Toast.makeText(this, "FCM can't post notifications without POST_NOTIFICATIONS permission",
+                Toast.LENGTH_LONG).show()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -50,6 +68,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         // [START initialize_functions_instance]
         functions = Firebase.functions
         // [END initialize_functions_instance]
+
+        askNotificationPermission()
     }
 
     // [START function_add_numbers]
@@ -224,6 +244,20 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             R.id.buttonCalculate -> onCalculateClicked()
             R.id.buttonAddMessage -> onAddMessageClicked()
             R.id.buttonSignIn -> onSignInClicked()
+        }
+    }
+
+    private fun askNotificationPermission() {
+        // This is only necessary for API Level > 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                // FCM SDK (and your app) can post notifications.
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
         }
     }
 

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -46,7 +46,11 @@ dependencies {
     implementation project(":internal:chooserx")
     implementation 'androidx.annotation:annotation:1.4.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'androidx.core:core:1.8.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+
+    // Required when asking for permission to post notifications (starting in Android 13)
+    implementation 'androidx.activity:activity-ktx:1.5.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.2'
 
     implementation 'com.google.android.material:material:1.6.1'
 

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MainActivity.java
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MainActivity.java
@@ -16,16 +16,21 @@
 
 package com.google.firebase.quickstart.fcm.java;
 
+import android.Manifest;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
@@ -36,6 +41,16 @@ import com.google.firebase.quickstart.fcm.databinding.ActivityMainBinding;
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "MainActivity";
+    private final ActivityResultLauncher<String> requestPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    Toast.makeText(this, "Notifications permission granted",Toast.LENGTH_SHORT)
+                            .show();
+                } else {
+                    Toast.makeText(this, "FCM can't post notifications without POST_NOTIFICATIONS permission",
+                            Toast.LENGTH_LONG).show();
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -117,6 +132,20 @@ public class MainActivity extends AppCompatActivity {
                 // [END log_reg_token]
             }
         });
+
+        askNotificationPermission();
     }
 
+    private void askNotificationPermission() {
+        // This is only necessary for API Level > 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                    PackageManager.PERMISSION_GRANTED) {
+                // FCM SDK (and your app) can post notifications.
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+            }
+        }
+    }
 }

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/java/MyFirebaseMessagingService.java
@@ -94,6 +94,10 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         // Check if message contains a notification payload.
         if (remoteMessage.getNotification() != null) {
             Log.d(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
+            String notificationBody = remoteMessage.getNotification().getBody();
+            if (remoteMessage.getNotification().getBody() != null) {
+                sendNotification(notificationBody);
+            }
         }
 
         // Also if you intend on generating your own notifications as a result of a received FCM
@@ -162,7 +166,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         Intent intent = new Intent(this, MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
-                PendingIntent.FLAG_ONE_SHOT);
+                PendingIntent.FLAG_IMMUTABLE);
 
         String channelId = getString(R.string.default_notification_channel_id);
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
@@ -1,12 +1,16 @@
 package com.google.firebase.quickstart.fcm.kotlin
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.messaging.ktx.messaging
@@ -14,6 +18,18 @@ import com.google.firebase.quickstart.fcm.R
 import com.google.firebase.quickstart.fcm.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            Toast.makeText(this, "Notifications permission granted",Toast.LENGTH_SHORT)
+                .show()
+        } else {
+            Toast.makeText(this, "FCM can't post notifications without POST_NOTIFICATIONS permission",
+                Toast.LENGTH_LONG).show()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -82,6 +98,21 @@ class MainActivity : AppCompatActivity() {
         }
 
         Toast.makeText(this, "See README for setup instructions", Toast.LENGTH_SHORT).show()
+        askNotificationPermission()
+    }
+
+    private fun askNotificationPermission() {
+        // This is only necessary for API Level > 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                // FCM SDK (and your app) can post notifications.
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
     }
 
     companion object {

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : AppCompatActivity() {
         ActivityResultContracts.RequestPermission()
     ) { isGranted: Boolean ->
         if (isGranted) {
-            Toast.makeText(this, "Notifications permission granted",Toast.LENGTH_SHORT)
+            Toast.makeText(this, "Notifications permission granted", Toast.LENGTH_SHORT)
                 .show()
         } else {
             Toast.makeText(this, "FCM can't post notifications without POST_NOTIFICATIONS permission",

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
@@ -54,6 +54,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         // Check if message contains a notification payload.
         remoteMessage.notification?.let {
             Log.d(TAG, "Message Notification Body: ${it.body}")
+            it.body?.let { body -> sendNotification(body) }
         }
 
         // Also if you intend on generating your own notifications as a result of a received FCM
@@ -116,7 +117,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         val intent = Intent(this, MainActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         val pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
-                PendingIntent.FLAG_ONE_SHOT)
+                PendingIntent.FLAG_IMMUTABLE)
 
         val channelId = getString(R.string.default_notification_channel_id)
         val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)


### PR DESCRIPTION
### API Level 31

Starting in API Level 31, Notifications' Pending Intent should use `PendingIntent.FLAG_IMMUTABLE`.

### API Level 33

Starting in API Level 33, apps should explicitly request the `POST_NOTIFICATION` permission as shown in our [docs](https://firebase.google.com/docs/cloud-messaging/android/client#request-permission13).