### PR TITLE
refactor(*): move namespace from AndroidManifest.xml to build.gradle file

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.samples.quickstart.admobexample'
     compileSdkVersion 33
 
     defaultConfig {

--- a/admob/app/src/main/AndroidManifest.xml
+++ b/admob/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.samples.quickstart.admobexample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- [SNIPPET modify_app_permissions]
         Include required permissions for Google Mobile Ads to run.

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.analytics'
     compileSdkVersion 33
 
     defaultConfig {

--- a/analytics/app/src/main/AndroidManifest.xml
+++ b/analytics/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.google.firebase.quickstart.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/appdistribution/app/build.gradle
+++ b/appdistribution/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.google.firebase.appdistributionquickstart'
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.google.firebase.appdistributionquickstart"

--- a/appdistribution/app/src/main/AndroidManifest.xml
+++ b/appdistribution/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.appdistributionquickstart">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name="androidx.multidex.MultiDexApplication"

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.auth'
     compileSdkVersion 33
     flavorDimensions "minSdkVersion"
 

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.firebase.quickstart.auth">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.samples.quickstart.config'
     compileSdkVersion 33
 
     defaultConfig {

--- a/config/app/src/main/AndroidManifest.xml
+++ b/config/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.quickstart.config" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.samples.quickstart.crash'
     compileSdkVersion 33
 
     defaultConfig {

--- a/crash/app/src/main/AndroidManifest.xml
+++ b/crash/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.quickstart.crash">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.database'
     compileSdkVersion 33
 
     defaultConfig {

--- a/database/app/src/main/AndroidManifest.xml
+++ b/database/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.database">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/dynamiclinks/app/build.gradle
+++ b/dynamiclinks/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleMainFlavorDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.deeplinks'
     compileSdkVersion 33
     flavorDimensions "irrelevant"
 

--- a/dynamiclinks/app/src/main/AndroidManifest.xml
+++ b/dynamiclinks/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.deeplinks" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 android {
+    namespace 'com.google.firebase.example.fireeats'
     testBuildType "release"
     compileSdkVersion 33
 

--- a/firestore/app/src/androidTest/AndroidManifest.xml
+++ b/firestore/app/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.google.firebase.example.fireeats"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
 

--- a/firestore/app/src/main/AndroidManifest.xml
+++ b/firestore/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.example.fireeats">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.google.samples.quickstart.functions'
     // Changes the test build type for instrumented tests to "stage".
     testBuildType "release"
     compileSdkVersion 33

--- a/functions/app/src/androidTest/AndroidManifest.xml
+++ b/functions/app/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.google.samples.quickstart.functions"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
 

--- a/functions/app/src/main/AndroidManifest.xml
+++ b/functions/app/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.quickstart.functions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace 'com.google.firebase.fiamquickstart'
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.google.firebase.fiamquickstart"

--- a/inappmessaging/app/src/main/AndroidManifest.xml
+++ b/inappmessaging/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.fiamquickstart">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name="androidx.multidex.MultiDexApplication"

--- a/internal/chooserx/build.gradle
+++ b/internal/chooserx/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 android {
+    namespace 'com.firebase.example.internal'
     compileSdkVersion 33
 
     defaultConfig {

--- a/internal/chooserx/src/main/AndroidManifest.xml
+++ b/internal/chooserx/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.firebase.example.internal">
+<manifest>
 </manifest>

--- a/internal/lintchecks/build.gradle
+++ b/internal/lintchecks/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
 }
 android {
+    namespace 'com.firebase.lintchecks'
     compileSdkVersion 33
 
     defaultConfig {

--- a/internal/lintchecks/src/main/AndroidManifest.xml
+++ b/internal/lintchecks/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.firebase.lintchecks" />
+<manifest />

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.fcm'
     compileSdkVersion 33
 
     defaultConfig {

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.firebase.quickstart.fcm">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 check.dependsOn 'assembleDebugAndroidTest'
 
 android {
+    namespace 'com.google.firebase.quickstart.perfmon'
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.google.firebase.quickstart.perfmon"

--- a/perf/app/src/main/AndroidManifest.xml
+++ b/perf/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.perfmon">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -29,6 +29,7 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    namespace 'com.google.firebase.quickstart.firebasestorage'
 }
 
 dependencies {

--- a/storage/app/src/main/AndroidManifest.xml
+++ b/storage/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.firebasestorage">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Used only for testing purposes, not required for Firebase Storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Starting in AGP 7.3.0, setting the ~package~ namespace on the AndroidManifest.xml file has been [deprecated](https://developer.android.com/studio/build/configure-app-module#set-namespace) in favor of setting it on the build.gradle file.

This PR should update our quickstarts to move the namespace to build.gradle.