### PR TITLE
Revert "Auto-update dependencies."

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-ads:21.3.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Analytics (Java)
     implementation 'com.google.firebase:firebase-analytics'

--- a/appdistribution/app/build.gradle
+++ b/appdistribution/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // ADD the SDK to the "prerelease" variant only (example)
     implementation 'com.google.firebase:firebase-appdistribution-ktx:16.0.0-beta01'

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Authentication (Java)
     implementation 'com.google.firebase:firebase-auth'
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx'
 
     // Google Identity Services SDK (only required for Auth with Google)
-    implementation 'com.google.android.gms:play-services-auth:20.4.0'
+    implementation 'com.google.android.gms:play-services-auth:20.3.0'
 
     // Firebase UI
     // Used in FirebaseUIActivity.

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Remote Config (Java)
     implementation 'com.google.firebase:firebase-config'

--- a/crash/app/build.gradle
+++ b/crash/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.6.1"
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Crashlytics (Kotlin)
     implementation 'com.google.firebase:firebase-crashlytics-ktx'

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Realtime Database (Java)
     implementation 'com.google.firebase:firebase-database'

--- a/dynamiclinks/app/build.gradle
+++ b/dynamiclinks/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Dynamic Links (Java)
     implementation 'com.google.firebase:firebase-dynamic-links'

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation project(":internal:chooserx")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firestore (Java)
     implementation 'com.google.firebase:firebase-firestore'
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx'
 
     // Google Play services
-    implementation 'com.google.android.gms:play-services-auth:20.4.0'
+    implementation 'com.google.android.gms:play-services-auth:20.3.0'
 
     // FirebaseUI (for authentication)
     implementation 'com.firebaseui:firebase-ui-auth:8.0.2'

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -44,13 +44,18 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Cloud Functions for Firebase (Java)
     implementation 'com.google.firebase:firebase-functions'
 
     // Cloud Functions for Firebase (Kotlin)
     implementation 'com.google.firebase:firebase-functions-ktx'
+
+    // TODO(thatfiredev): remove this explicit dependency once
+    //  https://github.com/firebase/firebase-android-sdk/issues/4206 is fixed.
+    // This is workaround to prevent the clash with firebase-messaging
+    implementation 'com.google.firebase:firebase-iid:21.1.0'
 
     // Firebase Authentication (Java)
     implementation 'com.google.firebase:firebase-auth'
@@ -65,7 +70,7 @@ dependencies {
     implementation 'com.firebaseui:firebase-ui-auth:8.0.2'
     
     // Google Play services
-    implementation 'com.google.android.gms:play-services-auth:20.4.0'
+    implementation 'com.google.android.gms:play-services-auth:20.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // FIAM (Java)
     implementation 'com.google.firebase:firebase-inappmessaging-display'

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Cloud Messaging (Java)
     implementation 'com.google.firebase:firebase-messaging'

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation project(":internal:chooserx")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Firebase Performance Monitoring (Java)
     implementation 'com.google.firebase:firebase-perf'

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation project(":internal:chooserx")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation platform('com.google.firebase:firebase-bom:31.1.0')
+    implementation platform('com.google.firebase:firebase-bom:31.0.3')
 
     // Cloud Storage for Firebase (Java)
     implementation 'com.google.firebase:firebase-storage'


### PR DESCRIPTION
Reverts firebase/quickstart-android#1434

According to the [release notes](https://github.com/JetBrains/kotlin/releases/tag/v1.7.22), this version is a "technical release". I'm not sure what that means, but apparently it doesn't contain any relevant fix from 1.7.21.