### PR TITLE
setActivity for PhoneAuthOptions in MFA Enroll

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/MultiFactorEnrollFragment.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/java/MultiFactorEnrollFragment.java
@@ -110,6 +110,7 @@ public class MultiFactorEnrollFragment extends BaseFragment {
                                 if (task.isSuccessful()) {
                                     PhoneAuthOptions phoneAuthOptions =
                                             PhoneAuthOptions.newBuilder()
+                                                    .setActivity(requireActivity())
                                                     .setPhoneNumber(phoneNumber)
                                                     // A timeout of 0 disables SMS-auto-retrieval.
                                                     .setTimeout(0L, TimeUnit.SECONDS)

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/MultiFactorEnrollFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/MultiFactorEnrollFragment.kt
@@ -78,6 +78,7 @@ class MultiFactorEnrollFragment : BaseFragment() {
                 .addOnCompleteListener { task ->
                     if (task.isSuccessful) {
                         val phoneAuthOptions = PhoneAuthOptions.newBuilder()
+                                .setActivity(requireActivity())
                                 .setPhoneNumber(phoneNumber) // A timeout of 0 disables SMS-auto-retrieval.
                                 .setTimeout(0L, TimeUnit.SECONDS)
                                 .setMultiFactorSession(task.result!!)


### PR DESCRIPTION
Issue: MFA Enroll flow in Firebase Auth Quickstart does not work. Enrolling MFA fails with a null pointer exception:
`java.lang.NullPointerException: You must specify an Activity on your PhoneAuthOptions. Please call #setActivity()`

Action: Fixed by calling setActivity() in PhoneAuthOptions.
