### PR TITLE
refactor(auth): fix generic idp provider spinner not showing

### DIFF
--- a/auth/app/src/main/res/layout/fragment_generic_idp.xml
+++ b/auth/app/src/main/res/layout/fragment_generic_idp.xml
@@ -64,7 +64,7 @@
             android:text="@string/generic_label_provider"
             android:textSize="16sp"
             android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="@+id/detail"
+            app:layout_constraintStart_toStartOf="@+id/titleText"
             app:layout_constraintTop_toBottomOf="@+id/detail" />
 
         <Spinner
@@ -75,7 +75,7 @@
             android:layout_toEndOf="@+id/providerSpinnerLabel"
             android:layout_toRightOf="@+id/providerSpinnerLabel"
             app:layout_constraintBottom_toBottomOf="@+id/providerSpinnerLabel"
-            app:layout_constraintEnd_toEndOf="@+id/detail"
+            app:layout_constraintEnd_toEndOf="@+id/titleText"
             app:layout_constraintStart_toEndOf="@+id/providerSpinnerLabel"
             app:layout_constraintTop_toTopOf="@+id/providerSpinnerLabel" />
 


### PR DESCRIPTION
The `@id/detail` TextView is hidden when the Generic Idp Fragment is launched, which causes the Views constrainted to that TextView to be out of place.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/16766726/214152276-777f3845-3670-4955-8e84-780ee3ed02c5.png" width="240px"></td>
<td><img src="https://user-images.githubusercontent.com/16766726/214152286-eba0365c-90b7-46eb-871b-61938ada717e.png" width="240px"></td>
</tr>
</table>

