### PR TITLE
chore: update ktlint 0.31.0 --> 0.48.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,11 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.github.shyiko:ktlint:0.31.0"
+    ktlint ("com.pinterest:ktlint:0.48.2") {
+        attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
+        }
+    }
 }
 
 task("ktlint", type: JavaExec, group: "verification") {
@@ -72,7 +76,7 @@ task("ktlint", type: JavaExec, group: "verification") {
 
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.github.shyiko.ktlint.Main"
+    mainClass.set("com.pinterest.ktlint.Main")
     args = [
         "--format",
         "--android",


### PR DESCRIPTION
The ktlint library we're using at the moment is no longer maintained, meaning that newer Kotlin features such as trailing commas are being marked as errors by the linter (see [example build failure](https://github.com/firebase/quickstart-android/actions/runs/4050382926/jobs/6967720321) from #1453).

Pinterest forked ktlint and continued development - their fork still uses the same MIT License as the original project, so it should be fine for us to use here.

This PR migrates to the fork and uses the latest version of the ktlint library.