### PR TITLE
unified imports

### DIFF
--- a/admob/app/src/main/java/com/google/samples/quickstart/admobexample/EntryChoiceActivity.kt
+++ b/admob/app/src/main/java/com/google/samples/quickstart/admobexample/EntryChoiceActivity.kt
@@ -3,7 +3,6 @@ package com.google.samples.quickstart.admobexample
 import android.content.Intent
 import com.firebase.example.internal.BaseEntryChoiceActivity
 import com.firebase.example.internal.Choice
-import com.google.samples.quickstart.admobexample.java.MainActivity
 
 class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
@@ -12,7 +11,7 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
                 Choice(
                         "Java",
                         "Run the Firebase Admob quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
+                        Intent(this, com.google.samples.quickstart.admobexample.java.MainActivity::class.java)),
                 Choice(
                         "Kotlin",
                         "Run the Firebase Admob quickstart written in Kotlin.",

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/EntryChoiceActivity.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/EntryChoiceActivity.kt
@@ -3,7 +3,6 @@ package com.google.firebase.quickstart.auth
 import android.content.Intent
 import com.firebase.example.internal.BaseEntryChoiceActivity
 import com.firebase.example.internal.Choice
-import com.google.firebase.quickstart.auth.java.MainActivity
 
 class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
@@ -12,7 +11,7 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
                 Choice(
                         "Java",
                         "Run the Firebase Auth quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
+                        Intent(this, com.google.firebase.quickstart.auth.java.MainActivity::class.java)),
                 Choice(
                         "Kotlin",
                         "Run the Firebase Auth quickstart written in Kotlin.",

--- a/crash/app/src/main/java/com/google/samples/quickstart/crash/EntryChoiceActivity.kt
+++ b/crash/app/src/main/java/com/google/samples/quickstart/crash/EntryChoiceActivity.kt
@@ -3,7 +3,6 @@ package com.google.samples.quickstart.crash
 import android.content.Intent
 import com.firebase.example.internal.BaseEntryChoiceActivity
 import com.firebase.example.internal.Choice
-import com.google.samples.quickstart.crash.java.MainActivity
 
 class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
@@ -12,7 +11,7 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
                 Choice(
                         "Java",
                         "Run the Firebase Crash quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
+                        Intent(this, com.google.samples.quickstart.crash.java.MainActivity::class.java)),
                 Choice(
                         "Kotlin",
                         "Run the Firebase Crash quickstart written in Kotlin.",

--- a/functions/app/src/main/java/com/google/samples/quickstart/functions/EntryChoiceActivity.kt
+++ b/functions/app/src/main/java/com/google/samples/quickstart/functions/EntryChoiceActivity.kt
@@ -3,7 +3,6 @@ package com.google.samples.quickstart.functions
 import android.content.Intent
 import com.firebase.example.internal.BaseEntryChoiceActivity
 import com.firebase.example.internal.Choice
-import com.google.samples.quickstart.functions.java.MainActivity
 
 class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
@@ -12,7 +11,7 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
                 Choice(
                         "Java",
                         "Run the Firebase Functions quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
+                        Intent(this, com.google.samples.quickstart.functions.java.MainActivity::class.java)),
                 Choice(
                         "Kotlin",
                         "Run the Firebase Functions quickstart written in Kotlin.",

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/EntryChoiceActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/EntryChoiceActivity.kt
@@ -3,7 +3,6 @@ package com.google.firebase.quickstart.fcm
 import android.content.Intent
 import com.firebase.example.internal.BaseEntryChoiceActivity
 import com.firebase.example.internal.Choice
-import com.google.firebase.quickstart.fcm.java.MainActivity
 
 class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
@@ -12,7 +11,7 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
                 Choice(
                         "Java",
                         "Run the Firebase Cloud Messaging quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
+                        Intent(this, com.google.firebase.quickstart.fcm.java.MainActivity::class.java)),
                 Choice(
                         "Kotlin",
                         "Run the Firebase Cloud Messaging written in Kotlin.",


### PR DESCRIPTION
Currently, if you look at all EntryChoiceActivity, most of them use unifying MainActivity.

And in some apps, you can also see that it's divided into MainActivity and Kotlin MainActivity
I thought if it wasn't named like the picture below, I might be confused if it was java or kotlin or both Kotlin MainActivity.
![image](https://user-images.githubusercontent.com/90879448/234166486-92951fd1-5442-49ee-aa41-b308b22d3bbe.png)

<br/>
So I unified the import so that developers could easily tell if it was java's MainActivity or Kotlin's MainActivity.


