### PR TITLE
prevent ktlint from being updated

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.register<JavaExec>("ktlintCheck") {
 }
 
 fun isNonStable(candidate: ModuleComponentIdentifier): Boolean {
-    return listOf("alpha", "beta", "rc", "snapshot", "-m").any { keyword ->
+    return listOf("alpha", "beta", "rc", "snapshot", "-m", "final").any { keyword ->
         keyword in candidate.version.lowercase()
     }
 }


### PR DESCRIPTION
This should prevent DPE Bot from opening issues like #1537 :

![Screenshot 2023-10-23 at 18 21 24](https://github.com/firebase/quickstart-android/assets/16766726/bbf8141a-54b7-41cb-94f7-f9d169859d49)

This is a temporary fix until we update to ktlint-cli 1.0