### PR TITLE
refactor(analytics, fiam): use BoM 32.5.0 and drop ktx

### DIFF
--- a/analytics/app/build.gradle.kts
+++ b/analytics/app/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation(platform("com.google.firebase:firebase-bom:32.4.1"))
+    implementation(platform("com.google.firebase:firebase-bom:32.5.0"))
 
     // Firebase Analytics
     implementation("com.google.firebase:firebase-analytics")

--- a/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/quickstart/analytics/kotlin/MainActivity.kt
@@ -15,10 +15,10 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
+import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.analytics.ktx.logEvent
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
 import com.google.firebase.quickstart.analytics.R
 import com.google.firebase.quickstart.analytics.databinding.ActivityMainBinding
 import com.google.firebase.quickstart.analytics.kotlin.MainActivity.Companion.IMAGE_INFOS

--- a/inappmessaging/app/build.gradle.kts
+++ b/inappmessaging/app/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("androidx.multidex:multidex:2.0.1")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation(platform("com.google.firebase:firebase-bom:32.4.1"))
+    implementation(platform("com.google.firebase:firebase-bom:32.5.0"))
 
     // FIAM
     implementation("com.google.firebase:firebase-inappmessaging-display")

--- a/inappmessaging/app/src/main/java/com/google/firebase/fiamquickstart/kotlin/KotlinMainActivity.kt
+++ b/inappmessaging/app/src/main/java/com/google/firebase/fiamquickstart/kotlin/KotlinMainActivity.kt
@@ -5,13 +5,13 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.fiamquickstart.R
 import com.google.firebase.fiamquickstart.databinding.ActivityMainBinding
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging
 import com.google.firebase.inappmessaging.inAppMessaging
 import com.google.firebase.installations.installations
 import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
 
 class KotlinMainActivity : AppCompatActivity() {
 
@@ -23,7 +23,7 @@ class KotlinMainActivity : AppCompatActivity() {
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        firebaseAnalytics = com.google.firebase.ktx.Firebase.analytics
+        firebaseAnalytics = Firebase.analytics
         firebaseIam = Firebase.inAppMessaging
 
         firebaseIam.isAutomaticDataCollectionEnabled = true


### PR DESCRIPTION
Now that firebase/firebase-android-sdk#5457 has been fixed, we can finally migrate analytics out of ktx