### PR TITLE
ci: run gradle assemble instead of build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 17
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Copy mock google_services.json
@@ -22,5 +24,5 @@ jobs:
       run: ./build_pull_request.sh
       if: github.event_name == 'pull_request'
     - name: Build with Gradle (Push)
-      run: ./gradlew clean ktlint build
+      run: ./gradlew clean ktlint assemble
       if: github.event_name != 'pull_request'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,10 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 17
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
+        distribution: 'zulu'
         java-version: 17
     - name: Check Snippets
       run: python scripts/checksnippets.py


### PR DESCRIPTION
Trying to address #1491 

This PR should:
- Replace `gradle build` with `gradle assemble` in CI
  Realistically we don't need to build the whole project. We're mostly interested in making sure that the project compiles (we have very few automated tests).
- Add the gradle-build action to enable Gradle cache.
- Update actions/checkout to v4
- Update actions/setup-java to v3