### PR TITLE
chore(fcm): remove guava dependency

### DIFF
--- a/messaging/app/build.gradle.kts
+++ b/messaging/app/build.gradle.kts
@@ -77,10 +77,6 @@ dependencies {
 
     implementation("androidx.work:work-runtime:2.8.1")
 
-    // Needed to fix the error:
-    // Cannot access class 'com.google.common.util.concurrent.ListenableFuture'
-    implementation("com.google.guava:guava:32.1.3-android")
-
     // Testing dependencies
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.test:runner:1.5.2")


### PR DESCRIPTION
This workaround was added in #1534 due to an issue in the analytics SDK. Said issue seems to have been fixed in `firebase-analytics:21.5.0` as explained in https://github.com/firebase/firebase-android-sdk/issues/5467