### PR TITLE
Configuration of firebase.json due to firebase tools 13.0.0 breaking change

### DIFF
--- a/functions/firebase.json
+++ b/functions/firebase.json
@@ -1,1 +1,14 @@
-{}
+{
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In relation to firebase-tools 13.0.0 breaking change https://github.com/firebase/firebase-tools/pull/6555, Firebase CLI will only reserve functions directory when there is a functions configuration entry in firebase.json that does not specify the source directory.