### PR TITLE
DO NOT MERGE: sample PR to demo Crashlytics Gradle Plugin v3 build error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.android.library") version "8.4.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.23" apply false
     id("com.google.gms.google-services") version "4.4.1" apply false
-    id("com.google.firebase.crashlytics") version "2.9.9" apply false
+    id("com.google.firebase.crashlytics") version "3.0.0" apply false
     id("com.google.firebase.firebase-perf") version "1.4.2" apply false
     id("androidx.navigation.safeargs") version "2.7.7" apply false
     id("com.github.ben-manes.versions") version "0.51.0" apply true

--- a/crash/app/build.gradle.kts
+++ b/crash/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId = "com.google.samples.quickstart.crash"
-        minSdk = 19
+        minSdk = 21
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
@@ -56,7 +56,7 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.9.0")
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
-    implementation(platform("com.google.firebase:firebase-bom:32.8.1"))
+    implementation(platform("com.google.firebase:firebase-bom:33.0.0"))
 
     // Firebase Crashlytics
     implementation("com.google.firebase:firebase-crashlytics")

--- a/crash/app/build.gradle.kts
+++ b/crash/app/build.gradle.kts
@@ -47,6 +47,12 @@ android {
     buildFeatures {
         viewBinding = true
     }
+
+    // TODO(thatfiredev): Investigate why this is needed in M147
+    //   (this is not Crashlytics specific)
+    packaging {
+        resources.excludes.add("META-INF/kotlinx_coroutines_core.version")
+    }
 }
 
 dependencies {

--- a/crash/build.gradle.kts
+++ b/crash/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.android.library") version "8.4.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.23" apply false
     id("com.google.gms.google-services") version "4.4.1" apply false
-    id("com.google.firebase.crashlytics") version "2.9.9" apply false
+    id("com.google.firebase.crashlytics") version "3.0.0" apply false
 }
 
 allprojects {


### PR DESCRIPTION
After upgrading to v3.0.0 of the Crashlytics Gradle plugin I get the following build error:
```
Circular dependency between the following tasks:
:app:dataBindingGenBaseClassesDebug
+--- :app:mergeDebugResources
|    \--- :app:injectCrashlyticsMappingFileIdDebug
|         \--- :app:dataBindingGenBaseClassesDebug (*)
\--- :app:parseDebugLocalResources
     \--- :app:packageDebugResources
          \--- :app:injectCrashlyticsMappingFileIdDebug (*)
```

Logs in GH Actions: https://github.com/firebase/quickstart-android/actions/runs/8931492882/job/24533662975