### PR TITLE
chore(*): allow alpha and beta updates for Firebase libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,10 @@ tasks.register<JavaExec>("ktlintCheck") {
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
 }
 
+fun notFromFirebase(candidate: ModuleComponentIdentifier): Boolean {
+    return candidate.group != "com.google.firebase"
+}
+
 fun isNonStable(candidate: ModuleComponentIdentifier): Boolean {
     return listOf("alpha", "beta", "rc", "snapshot", "-m", "final").any { keyword ->
         keyword in candidate.version.lowercase()
@@ -73,7 +77,7 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
 
 tasks.withType<DependencyUpdatesTask> {
     rejectVersionIf {
-        isNonStable(candidate) || isBlockListed(candidate)
+        (isNonStable(candidate) && notFromFirebase(candidate)) || isBlockListed(candidate)
     }
 }
 


### PR DESCRIPTION
Firebase has started to release `alpha` and `beta` artifacts. We should let the bot update these dependencies to keep our quickstarts up to date.