### PR TITLE
Adding compose code for FCM

### DIFF
--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -8,12 +8,12 @@ check.dependsOn 'assembleDebugAndroidTest'
 
 android {
     namespace 'com.google.firebase.quickstart.fcm'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.google.firebase.quickstart.fcm"
         minSdk 21 // minSdk would be 19 without compose
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -96,6 +96,9 @@ dependencies {
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.activity:activity-compose:1.5.1'
+
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
+    implementation("com.google.accompanist:accompanist-permissions:0.30.1")
 
     // Testing dependencies
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -98,7 +98,6 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.5.1'
 
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
-    implementation("com.google.accompanist:accompanist-permissions:0.30.1")
 
     // Testing dependencies
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -55,6 +55,7 @@
             </intent-filter>
         </service>
         <!-- [END firebase_service] -->
+
     </application>
 
 </manifest>

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         </activity>
 
         <activity android:name=".kotlin.MainActivity" />
+        <activity android:name=".kotlin.ComposeMainActivity"/>
         <activity android:name=".java.MainActivity" />
 
         <service
@@ -55,7 +56,6 @@
             </intent-filter>
         </service>
         <!-- [END firebase_service] -->
-
     </application>
 
 </manifest>

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/EntryChoiceActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/EntryChoiceActivity.kt
@@ -9,14 +9,18 @@ class EntryChoiceActivity : BaseEntryChoiceActivity() {
 
     override fun getChoices(): List<Choice> {
         return kotlin.collections.listOf(
-                Choice(
-                        "Java",
-                        "Run the Firebase Cloud Messaging quickstart written in Java.",
-                        Intent(this, MainActivity::class.java)),
-                Choice(
-                        "Kotlin",
-                        "Run the Firebase Cloud Messaging written in Kotlin.",
-                        Intent(this, com.google.firebase.quickstart.fcm.kotlin.MainActivity::class.java))
+            Choice(
+                "Java",
+                "Run the Firebase Cloud Messaging quickstart written in Java.",
+                Intent(this, MainActivity::class.java)),
+            Choice(
+                "Kotlin",
+                "Run the Firebase Cloud Messaging written in Kotlin.",
+                Intent(this, com.google.firebase.quickstart.fcm.kotlin.MainActivity::class.java)),
+            Choice(
+                "Compose",
+                "Run the Firebase Cloud Messaging written in Compose.",
+                Intent(this, com.google.firebase.quickstart.fcm.kotlin.ComposeMainActivity::class.java))
         )
     }
 }

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ComposeMainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ComposeMainActivity.kt
@@ -1,0 +1,267 @@
+package com.google.firebase.quickstart.fcm.kotlin
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.firebase.quickstart.fcm.R
+import com.google.firebase.quickstart.fcm.kotlin.data.SubscriptionState
+import com.google.firebase.quickstart.fcm.kotlin.ui.theme.FirebaseMessagingTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class ComposeMainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            FirebaseMessagingTheme {
+                // A surface container using the 'background' color from the theme
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colors.background
+                ) {
+                    MainAppView()
+                }
+            }
+        }
+    }
+}
+
+
+@OptIn(ExperimentalPermissionsApi::class)
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun RequestNotificationPermissionDialog(
+    scope: CoroutineScope,
+    snackbarHostState: SnackbarHostState
+) {
+    val permissionState = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
+
+    val requestPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        var message = "Notifications permission granted"
+        if (!isGranted) {
+            message = "FCM can't post notifications without POST_NOTIFICATIONS permission"
+        }
+
+        scope.launch {
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    LaunchedEffect(permissionState) {
+        if (!permissionState.status.isGranted) {
+            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+}
+
+@Composable
+fun MainAppView(
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    fcmViewModel: FirebaseMessagingViewModel = viewModel(factory = FirebaseMessagingViewModel.Factory)
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val activity = context.findActivity()
+    val intent = activity?.intent
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        RequestNotificationPermissionDialog(scope, snackbarHostState)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_CREATE) {
+                //Create Notification Channel
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    fcmViewModel.setNotificationChannel(
+                        context,
+                        context.getString(R.string.default_notification_channel_id),
+                        context.getString(R.string.default_notification_channel_name)
+                    )
+                }
+
+                if (intent != null) {
+                    fcmViewModel.getNotificationData(intent)
+                }
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(key1 = fcmViewModel.token) {
+        fcmViewModel.token.collect {
+            if(it.isNotEmpty()) {
+                snackbarHostState.showSnackbar(context.getString(R.string.msg_token_fmt, it))
+            }
+        }
+    }
+
+    LaunchedEffect(key1 = fcmViewModel.subscriptionState) {
+        fcmViewModel.subscriptionState.collect { state ->
+            when (state) {
+                SubscriptionState.Success -> { snackbarHostState.showSnackbar(context.getString(R.string.msg_subscribed)) }
+                SubscriptionState.Failed -> { snackbarHostState.showSnackbar(context.getString(R.string.msg_subscribe_failed)) }
+                SubscriptionState.Loading -> { }
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        },
+        modifier = Modifier
+            .fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                backgroundColor = colorResource(R.color.colorPrimary)
+            ) {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.h6,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(8.dp),
+                    color = Color.White
+                )
+            }
+        },
+        content = { it ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(it)
+            ) {
+                MainContent(fcmViewModel)
+            }
+        }
+    )
+}
+
+@Composable
+fun MainContent(
+    fcmViewModel: FirebaseMessagingViewModel
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(R.drawable.firebase_lockup_400),
+            contentDescription = "Firebase logo",
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text = stringResource(R.string.quickstart_message),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .padding(top = 16.dp, start=8.dp, end=8.dp, bottom=16.dp)
+        )
+        Button(
+            modifier = Modifier
+                .width(200.dp)
+                .wrapContentHeight()
+                .padding(0.dp, 20.dp, 0.dp, 0.dp),
+            colors = ButtonDefaults.buttonColors(backgroundColor = colorResource(R.color.colorPrimary)),
+            onClick = {
+                fcmViewModel.getSubscribe("weather")
+            }
+        ) {
+            Text(
+                textAlign = TextAlign.Center,
+                text = stringResource(R.string.subscribe_to_weather).uppercase(),
+                color = Color.White,
+            )
+        }
+        Button(
+            modifier = Modifier
+                .width(200.dp)
+                .wrapContentHeight()
+                .padding(0.dp, 20.dp, 0.dp, 0.dp),
+            colors = ButtonDefaults.buttonColors(backgroundColor = colorResource(R.color.colorPrimary)),
+            onClick = {
+                fcmViewModel.getToken()
+            }
+        ) {
+            Text(
+                text = stringResource(R.string.log_token).uppercase(),
+                color = Color.White,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GreetingPreview() {
+    FirebaseMessagingTheme {
+        MainAppView()
+    }
+}
+
+fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ComposeMainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ComposeMainActivity.kt
@@ -254,7 +254,7 @@ fun MainContent(
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun MainAppViewPreview() {
     FirebaseMessagingTheme {
         MainAppView()
     }

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/FirebaseMessagingViewModel.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/FirebaseMessagingViewModel.kt
@@ -1,0 +1,100 @@
+package com.google.firebase.quickstart.fcm.kotlin
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.quickstart.fcm.kotlin.data.SubscriptionState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class FirebaseMessagingViewModel(
+    private val messaging: FirebaseMessaging
+): ViewModel() {
+
+    private var _token: MutableStateFlow<String> = MutableStateFlow("")
+    val token: MutableStateFlow<String> = _token
+
+    private var _subscriptionState = MutableStateFlow(SubscriptionState.Loading)
+    val subscriptionState: StateFlow<SubscriptionState> = _subscriptionState
+
+    fun setNotificationChannel(context: Context, channelId: String, channelName: String ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create channel to show notifications.
+            context.getSystemService(NotificationManager::class.java)?.createNotificationChannel(
+                NotificationChannel(
+                    channelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+    }
+
+    fun getNotificationData(intent: Intent) {
+        viewModelScope.launch {
+            intent.extras?.let {
+                it.keySet().forEach { key ->
+                    val value = intent.extras?.getString(key)
+                    Log.d(TAG, "Key: $key Value: $value")
+                }
+            }
+        }
+    }
+
+    fun getToken() {
+        viewModelScope.launch {
+            messaging.getToken().addOnCompleteListener(OnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    Log.w(TAG, "Fetching FCM registration token failed", task.exception)
+                    return@OnCompleteListener
+                }
+
+                _token.value = task.result
+                Log.d(TAG, "FCM registration Token: " + task.result)
+            })
+        }
+    }
+
+    fun getSubscribe(topicName: String) {
+        viewModelScope.launch {
+            Log.d(TAG, "Subscribing to topic: $topicName")
+            _subscriptionState.value = SubscriptionState.Loading
+            messaging.subscribeToTopic(topicName)
+                .addOnCompleteListener { task ->
+                    _subscriptionState.value = when {
+                        !task.isSuccessful -> SubscriptionState.Failed
+                        else -> {
+                            Log.d(TAG, "Subscribed to weather topic")
+                            SubscriptionState.Success
+                        }
+                    }
+                }
+        }
+    }
+
+    companion object {
+        const val TAG = "FCMViewModel"
+        // Used to inject this ViewModel's dependencies
+        // See also: https://developer.android.com/topic/libraries/architecture/viewmodel/viewmodel-factories
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(
+                modelClass: Class<T>,
+                extras: CreationExtras
+            ): T {
+                val firebaseMessaging = FirebaseMessaging.getInstance()
+                return FirebaseMessagingViewModel(firebaseMessaging) as T
+            }
+        }
+    }
+}

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/FirebaseMessagingViewModel.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/FirebaseMessagingViewModel.kt
@@ -1,21 +1,25 @@
 package com.google.firebase.quickstart.fcm.kotlin
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.quickstart.fcm.kotlin.data.SubscriptionState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class FirebaseMessagingViewModel(
     private val messaging: FirebaseMessaging
@@ -26,6 +30,19 @@ class FirebaseMessagingViewModel(
 
     private var _subscriptionState = MutableStateFlow(SubscriptionState.Loading)
     val subscriptionState: StateFlow<SubscriptionState> = _subscriptionState
+
+    fun askNotificationPermission(
+        context: Context,
+        requestPermissionLauncher: ActivityResultLauncher<String>
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_DENIED
+            ) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
 
     fun setNotificationChannel(context: Context, channelId: String, channelName: String ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -40,45 +57,37 @@ class FirebaseMessagingViewModel(
         }
     }
 
-    fun getNotificationData(intent: Intent) {
-        viewModelScope.launch {
-            intent.extras?.let {
-                it.keySet().forEach { key ->
-                    val value = intent.extras?.getString(key)
-                    Log.d(TAG, "Key: $key Value: $value")
-                }
+    fun logNotificationData(intent: Intent) {
+        intent.extras?.let {
+            it.keySet().forEach { key ->
+                val value = intent.extras?.getString(key)
+                Log.d(TAG, "Key: $key Value: $value")
             }
         }
     }
 
     fun getToken() {
         viewModelScope.launch {
-            messaging.getToken().addOnCompleteListener(OnCompleteListener { task ->
-                if (!task.isSuccessful) {
-                    Log.w(TAG, "Fetching FCM registration token failed", task.exception)
-                    return@OnCompleteListener
-                }
-
-                _token.value = task.result
-                Log.d(TAG, "FCM registration Token: " + task.result)
-            })
+            try {
+                _token.value = messaging.getToken().await()
+                Log.d(TAG, "FCM registration Token: ${_token.value}")
+            } catch(e: Exception) {
+                Log.w(TAG, "Fetching FCM registration token failed", e)
+            }
         }
     }
 
-    fun getSubscribe(topicName: String) {
+    fun subscribeToTopic(topicName: String) {
         viewModelScope.launch {
             Log.d(TAG, "Subscribing to topic: $topicName")
-            _subscriptionState.value = SubscriptionState.Loading
-            messaging.subscribeToTopic(topicName)
-                .addOnCompleteListener { task ->
-                    _subscriptionState.value = when {
-                        !task.isSuccessful -> SubscriptionState.Failed
-                        else -> {
-                            Log.d(TAG, "Subscribed to weather topic")
-                            SubscriptionState.Success
-                        }
-                    }
-                }
+            try {
+                messaging.subscribeToTopic(topicName).await()
+                Log.d(TAG, "Subscribed to $topicName topic")
+                _subscriptionState.value = SubscriptionState.Success
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to subscribe to $topicName", e)
+                _subscriptionState.value = SubscriptionState.Failed
+            }
         }
     }
 

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MainActivity.kt
@@ -1,14 +1,11 @@
 package com.google.firebase.quickstart.fcm.kotlin
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.quickstart.fcm.R
@@ -54,17 +51,16 @@ class MainActivity : AppCompatActivity() {
         //
         // Handle possible data accompanying notification message.
         // [START handle_data_extras]
-        viewModel.getNotificationData(intent)
+        viewModel.logNotificationData(intent)
         // [END handle_data_extras]
 
         binding.subscribeButton.setOnClickListener {
             // [START subscribe_topics]
-            viewModel.getSubscribe("weather")
+            viewModel.subscribeToTopic("weather")
             // [END subscribe_topics]
         }
 
         binding.logTokenButton.setOnClickListener {
-            // Get token
             // [START log_reg_token]
             viewModel.getToken()
             // [END log_reg_token]
@@ -87,28 +83,18 @@ class MainActivity : AppCompatActivity() {
                         Snackbar.make(findViewById(android.R.id.content),
                             getString(R.string.msg_subscribed), Snackbar.LENGTH_LONG).show()
                     }
-                    SubscriptionState.Failed -> { Snackbar.make(findViewById(android.R.id.content),
-                        getString(R.string.msg_subscribe_failed), Snackbar.LENGTH_LONG).show()
+                    SubscriptionState.Failed -> {
+                        Snackbar.make(findViewById(android.R.id.content),
+                            getString(R.string.msg_subscribe_failed), Snackbar.LENGTH_LONG).show()
                     }
                     SubscriptionState.Loading -> { }
                 }
             }
         }
-        Toast.makeText(this, "See README for setup instructions", Toast.LENGTH_SHORT).show()
-        askNotificationPermission()
-    }
+        Toast.makeText(this, getString(R.string.msg_setup_readme_instructions), Toast.LENGTH_SHORT).show()
 
-    private fun askNotificationPermission() {
-        // This is only necessary for API Level > 33 (TIRAMISU)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
-                PackageManager.PERMISSION_GRANTED
-            ) {
-                // FCM SDK (and your app) can post notifications.
-            } else {
-                // Directly ask for the permission
-                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
+        lifecycleScope.launch {
+            viewModel.askNotificationPermission(applicationContext, requestPermissionLauncher)
         }
     }
 

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.media.RingtoneManager
 import android.os.Build
 import android.util.Log
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.core.app.NotificationCompat
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
@@ -114,7 +113,6 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
      *
      * @param messageBody FCM message body received.
      */
-    @OptIn(ExperimentalMaterialApi::class)
     private fun sendNotification(messageBody: String) {
         val intent = Intent(this, MainActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/MyFirebaseMessagingService.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.media.RingtoneManager
 import android.os.Build
 import android.util.Log
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.core.app.NotificationCompat
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
@@ -113,6 +114,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
      *
      * @param messageBody FCM message body received.
      */
+    @OptIn(ExperimentalMaterialApi::class)
     private fun sendNotification(messageBody: String) {
         val intent = Intent(this, MainActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/data/SubscriptionState.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/data/SubscriptionState.kt
@@ -1,0 +1,5 @@
+package com.google.firebase.quickstart.fcm.kotlin.data
+
+enum class SubscriptionState {
+    Success, Failed, Loading
+}

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Color.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package com.google.firebase.quickstart.fcm.kotlin.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val FirebaseBlue = Color(0xFF0288D1) // copied from colors.xml
+val FirebaseBannerBlue = Color(0xFF039BE5) // copied from colors.xml
+val FirebaseOrange = Color(0xFFFFA000) // copied from colors.xml

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Shape.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Shape.kt
@@ -1,0 +1,11 @@
+package com.google.firebase.quickstart.fcm.kotlin.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Shapes
+import androidx.compose.ui.unit.dp
+
+val Shapes = Shapes(
+    small = RoundedCornerShape(16.dp),
+    medium = RoundedCornerShape(2.dp),
+    large = RoundedCornerShape(0.dp)
+)

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Theme.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Theme.kt
@@ -1,0 +1,38 @@
+package com.google.firebase.quickstart.fcm.kotlin.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+
+private val DarkColorPalette = darkColors(
+    primary = Purple80,
+    primaryVariant = PurpleGrey80,
+    secondary = Pink80
+)
+
+private val LightColorPalette = lightColors(
+    primary = FirebaseBlue,
+    primaryVariant = FirebaseBannerBlue,
+    secondary = FirebaseOrange
+)
+
+@Composable
+fun FirebaseMessagingTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+
+    MaterialTheme(
+        colors = colors,
+        typography = Typography,
+        shapes = Shapes,
+        content = content
+    )
+}

--- a/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Type.kt
+++ b/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/kotlin/ui/theme/Type.kt
@@ -1,0 +1,18 @@
+package com.google.firebase.quickstart.fcm.kotlin.ui.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    body1 = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+)

--- a/messaging/app/src/main/res/values/strings.xml
+++ b/messaging/app/src/main/res/values/strings.xml
@@ -19,4 +19,9 @@
     <!-- [END fcm_default_icon_string] -->
     <string name="msg_subscribe_failed">Failed to subscribe to weather topic</string>
     <string name="fcm_message">FCM Message</string>
+
+    <string name="msg_permission_granted">Notifications permission granted</string>
+    <string name="msg_permission_failed">FCM can\'t post notifications without POST_NOTIFICATIONS permission</string>
+
+    <string name="msg_setup_readme_instructions">See README for setup instructions</string>"
 </resources>

--- a/messaging/app/src/main/res/values/strings.xml
+++ b/messaging/app/src/main/res/values/strings.xml
@@ -23,5 +23,5 @@
     <string name="msg_permission_granted">Notifications permission granted</string>
     <string name="msg_permission_failed">FCM can\'t post notifications without POST_NOTIFICATIONS permission</string>
 
-    <string name="msg_setup_readme_instructions">See README for setup instructions</string>"
+    <string name="msg_setup_readme_instructions">See README for setup instructions</string>
 </resources>

--- a/messaging/gradle.properties
+++ b/messaging/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-
+android.useAndroidX=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Changes made:

- Add Jetpack Compose option in `EntryChoiceActivity`
- Removed business logic from `MainActivity`
- Added `FirebaseMessagingViewModel` for business logic
- Added `ComposeMainActivity` for the Jetpack Compose UI