### PR TITLE
Remove activity tag label

### DIFF
--- a/config/app/src/main/AndroidManifest.xml
+++ b/config/app/src/main/AndroidManifest.xml
@@ -5,19 +5,14 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
 
-        <activity
-            android:name=".java.MainActivity"
-            android:label="@string/app_name" />
+        <activity android:name=".java.MainActivity" />
 
-        <activity
-            android:name=".kotlin.MainActivity"
-            android:label="@string/app_name" />
+        <activity android:name=".kotlin.MainActivity" />
 
         <activity
             android:name=".EntryChoiceActivity"
-            android:label="@string/app_name"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Since the label name is the same as the application tag, there is no need to specify a label for the activity tag.