### PR TITLE
Upgrade firebase-dataconnect version to 16.0.0-beta03 (was 16.0.0-beta02)

### DIFF
--- a/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
+++ b/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
@@ -58,7 +58,7 @@ fun ReviewCard(
                 Text(
                     text =
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())
+                            val dateFormatter = DateTimeFormatter.ofPattern("dd MMM, yyyy", Locale.getDefault())
                             date.toJavaLocalDate().format(dateFormatter)
                         } else {
                             val parseableDateString = date.run {
@@ -70,7 +70,7 @@ fun ReviewCard(
                             val dateParser = SimpleDateFormat("y-M-d", Locale.US)
                             val parsedDate = dateParser.parse(parseableDateString) ?:
                               throw Exception("INTERNAL ERROR: unparseable date string: $parseableDateString")
-                            val dateFormatter = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+                            val dateFormatter = SimpleDateFormat("dd MMM, yyyy", Locale.getDefault())
                             dateFormatter.format(parsedDate)
                         },
                     style = MaterialTheme.typography.titleMedium

--- a/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
+++ b/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
@@ -54,10 +54,19 @@ fun ReviewCard(
                 modifier = Modifier.padding(bottom = 8.dp)
             ) {
                 Text(
-                    text = SimpleDateFormat(
-                        "dd MMM, yyyy",
-                        Locale.getDefault()
-                    ).format(date.toJavaLocalDate()),
+                    text = run {
+                        val parseableDateString = date.run {
+                            val year = "$year".padStart(4, '0')
+                            val month = "$month".padStart(2, '0')
+                            val day = "$day".padStart(2, '0')
+                            "$year-$month-$day"
+                        }
+                        val dateParser = SimpleDateFormat("y-M-d", Locale.US)
+                        val parsedDate = dateParser.parse(parseableDateString) ?:
+                          throw Exception("INTERNAL ERROR: unparseable date string: $parseableDateString")
+                        val dateFormatter = SimpleDateFormat("MMM d, yyyy", Locale.US)
+                        dateFormatter.format(parsedDate)
+                    },
                     style = MaterialTheme.typography.titleMedium
                 )
                 Spacer(modifier = Modifier.width(8.dp))

--- a/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
+++ b/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
@@ -17,17 +17,16 @@ import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.google.firebase.dataconnect.LocalDate
+import com.google.firebase.dataconnect.toJavaLocalDate
 import java.text.SimpleDateFormat
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.util.Date
 import java.util.Locale
 
 
 @Composable
 fun ReviewCard(
     userName: String,
-    date: Date,
+    date: LocalDate,
     rating: Double,
     text: String,
     movieName: String? = null
@@ -58,7 +57,7 @@ fun ReviewCard(
                     text = SimpleDateFormat(
                         "dd MMM, yyyy",
                         Locale.getDefault()
-                    ).format(date),
+                    ).format(date.toJavaLocalDate()),
                     style = MaterialTheme.typography.titleMedium
                 )
                 Spacer(modifier = Modifier.width(8.dp))

--- a/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
+++ b/dataconnect/app/src/main/java/com/google/firebase/example/dataconnect/ui/components/ReviewCard.kt
@@ -1,5 +1,6 @@
 package com.google.firebase.example.dataconnect.ui.components
 
+import android.os.Build
 import android.widget.Space
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.google.firebase.dataconnect.LocalDate
 import com.google.firebase.dataconnect.toJavaLocalDate
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 
@@ -54,19 +56,23 @@ fun ReviewCard(
                 modifier = Modifier.padding(bottom = 8.dp)
             ) {
                 Text(
-                    text = run {
-                        val parseableDateString = date.run {
-                            val year = "$year".padStart(4, '0')
-                            val month = "$month".padStart(2, '0')
-                            val day = "$day".padStart(2, '0')
-                            "$year-$month-$day"
-                        }
-                        val dateParser = SimpleDateFormat("y-M-d", Locale.US)
-                        val parsedDate = dateParser.parse(parseableDateString) ?:
-                          throw Exception("INTERNAL ERROR: unparseable date string: $parseableDateString")
-                        val dateFormatter = SimpleDateFormat("MMM d, yyyy", Locale.US)
-                        dateFormatter.format(parsedDate)
-                    },
+                    text =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            val dateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())
+                            date.toJavaLocalDate().format(dateFormatter)
+                        } else {
+                            val parseableDateString = date.run {
+                                val year = "$year".padStart(4, '0')
+                                val month = "$month".padStart(2, '0')
+                                val day = "$day".padStart(2, '0')
+                                "$year-$month-$day"
+                            }
+                            val dateParser = SimpleDateFormat("y-M-d", Locale.US)
+                            val parsedDate = dateParser.parse(parseableDateString) ?:
+                              throw Exception("INTERNAL ERROR: unparseable date string: $parseableDateString")
+                            val dateFormatter = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+                            dateFormatter.format(parsedDate)
+                        },
                     style = MaterialTheme.typography.titleMedium
                 )
                 Spacer(modifier = Modifier.width(8.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.7.2"
 coilCompose = "2.7.0"
 firebaseAuth = "23.1.0"
-firebaseDataConnect = "16.0.0-beta02"
+firebaseDataConnect = "16.0.0-beta03"
 kotlin = "2.0.21"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
This PR upgrades the `firebase-dataconnect` dependency to version to `16.0.0-beta03` (https://firebase.google.com/support/release-notes/android#data-connect_v16-0-0-beta03) from `16.0.0-beta02`.

This upgrade is a breaking change and requires Data Connect toolkit version 1.7.0 or later, which is available in firebase-tools version 13.25.0 (https://firebase.google.com/support/release-notes/cli#version_13250_-_november_12_2024). The breaking change is that the code generation for `Date` GraphQL fields and variables uses the new `com.google.firebase.dataconnect.LocalDate` class instead of `java.util.Date`. This new class has functions to convert it to `java.time.LocalDate` and `kotlinx.datetime.LocalDate`.

Since `java.time.LocalDate` was added to the Android standard library in API 26, special case must be taken if your application's version has a `minSdkVersion` less than 26. The options to use `java.time.LocalDate` in such an application are:
1. Just use `com.google.firebase.dataconnect.LocalDate`, without converting it to `java.time.LocalDate`.
2. Put code that uses the `java.time` package inside a `if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)` block.
3. Enable desugaring (https://developer.android.com/studio/write/java8-support) to make the `java.time.LocalDate` class available all the way back to API 21 (the `minSdkVersion` defined in the `firebase-dataconnect` module).

Also note that using `kotlinx.datetime.LocalDate` requires your application to take a dependency on the "kotlinx-datetime" library by adding `implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")` to the `dependencies` section of your "app" module's `build.gradle` or `build.gradle.kts`. In addition, the `kotlinx-datetime` library uses `java.time` under the hood, so has the same restrictions and requires the same mitigation strategies mentioned above.