### PR TITLE
fix: correct typos in README files.

### DIFF
--- a/admob/README.md
+++ b/admob/README.md
@@ -18,7 +18,7 @@ Getting Started
   - In `src/main/res/values/strings.xml` change the `admob_app_id` string to your AdMob app id.
   - Note that this ID is used in two places: `AndroidManifest.xml` and `MainActivity`
 - Run the sample on your Android device or emulator.
-- The running sample displays a test banner ad and a test interstitial add.
+- The running sample displays a test banner ad and a test interstitial ad.
 
 Result
 -----------

--- a/appdistribution/README.md
+++ b/appdistribution/README.md
@@ -1,4 +1,4 @@
-# Firebase App Distrbution Quickstart
+# Firebase App Distribution Quickstart
 
 ## Introduction
 


### PR DESCRIPTION
This pull request includes minor corrections to the documentation files for `admob` and `appdistribution` modules. The changes fix typos and improve clarity.

Documentation corrections:

* [`admob/README.md`](diffhunk://#diff-6ab894215d4a4910fc22dfd626eb3a937173eef941b87c06a5f812b1b096ca38L21-R21): Corrected a typo in the description of the running sample.
* [`appdistribution/README.md`](diffhunk://#diff-f02e0d087507f89b028b593059b5ee87ccf64fe64c6132732d9f73a09f4d7a32L1-R1): Fixed a typo in the title of the document.