### PR TITLE
pin the Functions SDK version

### DIFF
--- a/functions/app/build.gradle.kts
+++ b/functions/app/build.gradle.kts
@@ -54,7 +54,9 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
 
     // Cloud Functions for Firebase
-    implementation("com.google.firebase:firebase-functions")
+    // TODO(thatfiredev): remove the pinned dependency version when
+    //   https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
+    implementation("com.google.firebase:firebase-functions:21.0.0")
 
     // Firebase Authentication
     implementation("com.google.firebase:firebase-auth")


### PR DESCRIPTION
dpebot keeps trying to bump the Firebase BoM in the Functions quickstart, but runs into a build error due to firebase/firebase-android-sdk#6522

This PR should pin the Functions SDK version to the last working one before the break.
Once a new version of functions comes out with the fix for firebase/firebase-android-sdk#6522 we should revert this change.