### PR TITLE
add firebase-functions to list of blocklisted dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,8 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
             "com.facebook.android",
             "com.google.guava",
             "com.github.bumptech.glide",
-            "com.google.android.gms"
+            "com.google.android.gms",
+            "com.google.firebase:firebase-functions" // TODO(thatfiredev): remove once https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
     ).any { keyword ->
         keyword in candidate.toString().lowercase()
     }


### PR DESCRIPTION
This should be reverted at the same time as #2640