### PR TITLE
Add Credential Manager to Auth samples

### DIFF
--- a/auth/app/build.gradle.kts
+++ b/auth/app/build.gradle.kts
@@ -65,7 +65,9 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
 
     // Google Identity Services SDK (only required for Auth with Google)
-    implementation("com.google.android.gms:play-services-auth:21.2.0")
+    implementation("androidx.credentials:credentials:1.3.0")
+    implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
+    implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
 
     // Firebase UI
     // Used in FirebaseUIActivity.

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -115,6 +115,7 @@ class GoogleSignInFragment : BaseFragment() {
                 // Check if credential is of type Google ID
                 if (credential is CustomCredential && credential.type == TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
                     val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+                    // Sign in to Firebase with the Google ID Token
                     firebaseAuthWithGoogle(googleIdTokenCredential.idToken)
                 } else {
                     Log.d(TAG, "Credential is not of type Google ID!")

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -1,20 +1,22 @@
 package com.google.firebase.quickstart.auth.kotlin
 
-import android.app.PendingIntent
-import android.content.Intent
-import android.content.IntentSender
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
-import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
-import com.google.android.gms.auth.api.identity.Identity
-import com.google.android.gms.auth.api.identity.SignInClient
-import com.google.android.gms.common.api.ApiException
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.Credential
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.ClearCredentialException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.lifecycle.lifecycleScope
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential.Companion.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -23,6 +25,7 @@ import com.google.firebase.auth.auth
 import com.google.firebase.Firebase
 import com.google.firebase.quickstart.auth.R
 import com.google.firebase.quickstart.auth.databinding.FragmentGoogleBinding
+import kotlinx.coroutines.launch
 
 /**
  * Demonstrate Firebase Authentication using a Google ID Token.
@@ -35,11 +38,7 @@ class GoogleSignInFragment : BaseFragment() {
     private val binding: FragmentGoogleBinding
         get() = _binding!!
 
-    private lateinit var signInClient: SignInClient
-
-    private val signInLauncher = registerForActivityResult(StartIntentSenderForResult()) { result ->
-        handleSignInResult(result.data)
-    }
+    private lateinit var credentialManager: CredentialManager
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentGoogleBinding.inflate(inflater, container, false)
@@ -51,20 +50,30 @@ class GoogleSignInFragment : BaseFragment() {
 
         setProgressBar(binding.progressBar)
 
-        // Button listeners
-        binding.signInButton.setOnClickListener { signIn() }
-        binding.signOutButton.setOnClickListener { signOut() }
-
-        // Configure Google Sign In
-        signInClient = Identity.getSignInClient(requireContext())
+        // Initialize Credential Manager
+        credentialManager = CredentialManager.create(requireContext())
 
         // Initialize Firebase Auth
         auth = Firebase.auth
 
-        // Display One-Tap Sign In if user isn't logged in
-        val currentUser = auth.currentUser
-        if (currentUser == null) {
-            oneTapSignIn()
+        // Button listeners
+        binding.signInButton.setOnClickListener {
+            viewLifecycleOwner.lifecycleScope.launch {
+                launchCredManButtonUI()
+            }
+        }
+
+        binding.signOutButton.setOnClickListener {
+            viewLifecycleOwner.lifecycleScope.launch {
+                signOut()
+            }
+        }
+
+        // Display Credential Manager Bottom Sheet if user isn't logged in
+        if (auth.currentUser == null) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                launchCredManBottomSheet()
+            }
         }
     }
 
@@ -75,30 +84,75 @@ class GoogleSignInFragment : BaseFragment() {
         updateUI(currentUser)
     }
 
-    private fun handleSignInResult(data: Intent?) {
-        // Result returned from launching the Sign In PendingIntent
+    private suspend fun launchCredManButtonUI() {
         try {
-            // Google Sign In was successful, authenticate with Firebase
-            val credential = signInClient.getSignInCredentialFromIntent(data)
-            val idToken = credential.googleIdToken
-            if (idToken != null) {
-                Log.d(TAG, "firebaseAuthWithGoogle: ${credential.id}")
-                firebaseAuthWithGoogle(idToken)
-            } else {
-                // Shouldn't happen.
-                Log.d(TAG, "No ID token!")
-            }
-        } catch (e: ApiException) {
-            // Google Sign In failed, update UI appropriately
-            Log.w(TAG, "Google sign in failed", e)
-            updateUI(null)
+            val context = requireContext()
+
+            // Create the dialog configuration for the Credential Manager request
+            val signInWithGoogleOption = GetSignInWithGoogleOption
+                .Builder(serverClientId = context.getString(R.string.default_web_client_id))
+                .build()
+
+            // Create the Credential Manager request using the configuration created above
+            val request = GetCredentialRequest.Builder()
+                .addCredentialOption(signInWithGoogleOption)
+                .build()
+
+            // Launch the dialog UI
+            val result = credentialManager.getCredential(
+                request = request,
+                context = context
+            )
+
+            // Result returned from launching the Sign In Dialog
+            onCredentialRequestResult(result.credential)
+        } catch (e: GetCredentialException) {
+            Log.e(TAG, "Couldn't start Sign In: ${e.localizedMessage}")
+        }
+    }
+
+    private suspend fun launchCredManBottomSheet() {
+        try {
+            val context = requireContext()
+
+            // Create the bottom sheet configuration for the Credential Manager request
+            val googleIdOption = GetGoogleIdOption.Builder()
+                .setFilterByAuthorizedAccounts(true)
+                .setServerClientId(context.getString(R.string.default_web_client_id))
+                .build()
+
+            // Create the Credential Manager request using the configuration created above
+            val request = GetCredentialRequest.Builder()
+                .addCredentialOption(googleIdOption)
+                .build()
+
+            // Launch the bottom sheet UI
+            val result = credentialManager.getCredential(
+                request = request,
+                context = context
+            )
+
+            // Result returned from launching the Sign In Bottom Sheet
+            onCredentialRequestResult(result.credential)
+        } catch (e: GetCredentialException) {
+            Log.e(TAG, "Couldn't start Sign In: ${e.localizedMessage}")
+        }
+    }
+
+    private fun onCredentialRequestResult(credential: Credential) {
+        // Check if credential is of type Google ID (as Credential Manager offers various credential options)
+        if (credential is CustomCredential && credential.type == TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+            firebaseAuthWithGoogle(googleIdTokenCredential.idToken)
+        } else {
+            Log.d(TAG, "Credential is not of type Google ID!")
         }
     }
 
     private fun firebaseAuthWithGoogle(idToken: String) {
         showProgressBar()
-        val credential = GoogleAuthProvider.getCredential(idToken, null)
-        auth.signInWithCredential(credential)
+        val firebaseCredential = GoogleAuthProvider.getCredential(idToken, null)
+        auth.signInWithCredential(firebaseCredential)
             .addOnCompleteListener(requireActivity()) { task ->
                 if (task.isSuccessful) {
                     // Sign in success, update UI with the signed-in user's information
@@ -117,60 +171,18 @@ class GoogleSignInFragment : BaseFragment() {
             }
     }
 
-    private fun signIn() {
-        val signInRequest = GetSignInIntentRequest.builder()
-            .setServerClientId(getString(R.string.default_web_client_id))
-            .build()
-
-        signInClient.getSignInIntent(signInRequest)
-            .addOnSuccessListener { pendingIntent ->
-                launchSignIn(pendingIntent)
-            }
-            .addOnFailureListener { e ->
-                Log.e(TAG, "Google Sign-in failed", e)
-            }
-    }
-
-    private fun oneTapSignIn() {
-        // Configure One Tap UI
-        val oneTapRequest = BeginSignInRequest.builder()
-            .setGoogleIdTokenRequestOptions(
-                BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-                    .setSupported(true)
-                    .setServerClientId(getString(R.string.default_web_client_id))
-                    .setFilterByAuthorizedAccounts(true)
-                    .build(),
-            )
-            .build()
-
-        // Display the One Tap UI
-        signInClient.beginSignIn(oneTapRequest)
-            .addOnSuccessListener { result ->
-                launchSignIn(result.pendingIntent)
-            }
-            .addOnFailureListener { e ->
-                // No saved credentials found. Launch the One Tap sign-up flow, or
-                // do nothing and continue presenting the signed-out UI.
-            }
-    }
-
-    private fun launchSignIn(pendingIntent: PendingIntent) {
-        try {
-            val intentSenderRequest = IntentSenderRequest.Builder(pendingIntent)
-                .build()
-            signInLauncher.launch(intentSenderRequest)
-        } catch (e: IntentSender.SendIntentException) {
-            Log.e(TAG, "Couldn't start Sign In: ${e.localizedMessage}")
-        }
-    }
-
-    private fun signOut() {
+    private suspend fun signOut() {
         // Firebase sign out
         auth.signOut()
 
-        // Google sign out
-        signInClient.signOut().addOnCompleteListener(requireActivity()) {
+        // When a user signs out, clear the current user credential state from all credential providers.
+        // This will notify all providers that any stored credential session for the given app should be cleared.
+        try {
+            val clearRequest = ClearCredentialStateRequest()
+            credentialManager.clearCredentialState(clearRequest)
             updateUI(null)
+        } catch (e: ClearCredentialException) {
+            Log.e(TAG, "Couldn't clear user credentials: ${e.localizedMessage}")
         }
     }
 

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/kotlin/GoogleSignInFragment.kt
@@ -105,8 +105,8 @@ class GoogleSignInFragment : BaseFragment() {
             try {
                 // Launch Credential Manager UI
                 val result = credentialManager.getCredential(
-                    request = request,
-                    context = requireContext()
+                    context = requireContext(),
+                    request = request                    
                 )
 
                 // Extract credential from the result returned by Credential Manager


### PR DESCRIPTION
This PR:

- Removes Google One Tap sign-in, which is deprecated 
- Adds Credential Manager, which is the recommended way to fetch users' credentials