### PR TITLE
chore: unpin functions version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,8 +71,7 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
             "com.facebook.android",
             "com.google.guava",
             "com.github.bumptech.glide",
-            "com.google.android.gms",
-            "com.google.firebase:firebase-functions" // TODO(thatfiredev): remove once https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
+            "com.google.android.gms"
     ).any { keyword ->
         keyword in candidate.toString().lowercase()
     }

--- a/functions/app/build.gradle.kts
+++ b/functions/app/build.gradle.kts
@@ -54,9 +54,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
 
     // Cloud Functions for Firebase
-    // TODO(thatfiredev): remove the pinned dependency version when
-    //   https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
-    implementation("com.google.firebase:firebase-functions:21.0.0")
+    implementation("com.google.firebase:firebase-functions")
 
     // Firebase Authentication
     implementation("com.google.firebase:firebase-auth")


### PR DESCRIPTION
This should undo the changes from #2640 and #2641 now that https://github.com/firebase/firebase-android-sdk/issues/6522 has been fixed