### PR TITLE
chore(ai): use kotlin 2.2.0

### DIFF
--- a/firebase-ai/app/build.gradle.kts
+++ b/firebase-ai/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
-    kotlin("plugin.serialization") version "2.1.21"
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.gms.google-services")
 }
 

--- a/firebase-ai/build.gradle.kts
+++ b/firebase-ai/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
     id("com.android.library") version "8.10.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.10.1"
 coilCompose = "2.7.0"
 firebaseBom = "33.15.0"
-kotlin = "2.1.21"
+kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
It seems like dpebot missed this in https://github.com/firebase/quickstart-android/pull/2681

The reason why it didn't update the build.gradle.kts file is because that file used the `kotlin(...)` function instead of `id(...)`.

I need to investigate why it didn't update the TOML as well (see https://github.com/firebase/quickstart-android/pull/2681#issuecomment-3036667136)