### PR TITLE
ci: improve the GitHub Actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,12 +1,19 @@
 name: Android CI
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,8 +3,6 @@ name: Android CI
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
This PR should:
* set a timeout of 30 minutes - our CI rarely takes more than that. Let's not use quotas unecessarily
* use concurrency to cancel previous workflows