### PR TITLE
ci: separate the GH actions workflows

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,0 +1,31 @@
+name: Build (Android)
+
+on:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: 17
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+    - name: Check Snippets
+      run: python scripts/checksnippets.py
+    # TODO(thatfiredev): remove this once github.com/firebase/quickstart-android/issues/1672 is fixed
+    - name: Remove Firebase Data Connect from CI
+      run: python scripts/ci_remove_fdc.py
+    - name: Copy mock google_services.json
+      run: ./copy_mock_google_services_json.sh
+    - name: Build with Gradle (Push)
+      run: ./gradlew clean ktlint assemble

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -1,8 +1,7 @@
-name: Android CI
+name: Build Pull Request
 
 on:
   pull_request:
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -30,7 +29,3 @@ jobs:
       run: ./copy_mock_google_services_json.sh
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh
-      if: github.event_name == 'pull_request'
-    - name: Build with Gradle (Push)
-      run: ./gradlew clean ktlint assemble
-      if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ Please read and follow the steps in the [CONTRIBUTING.md](CONTRIBUTING.md)
 [![SAM Score][sam-score-badge]][sam-score]
 
 [gh-actions]: https://github.com/firebase/quickstart-android/actions
-[gh-actions-badge]: https://github.com/firebase/quickstart-android/actions/workflows/android.yml/badge.svg?branch=master&event=push
+[gh-actions-badge]: https://github.com/firebase/quickstart-android/actions/workflows/build_branch.yml/badge.svg?branch=master&event=push
 [sam-score]: https://ossbot.computer/samscore.html
 [sam-score-badge]: https://ossbot.computer/samscorebadge?org=firebase&repo=quickstart-android


### PR DESCRIPTION
Since #2697 was merged, CI has been behaving unexpectedly with some flows being re-triggered for no reason and others being cancelled suddenly.
I wonder if this is related to the fact we have both workflows (PR and push) in the same workflow file, so I'm breaking it down into 2 different workflows.