### PR TITLE
ci(dataconnect): use dataconnect:compile to generate SDKs in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,15 +19,19 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: 17
+    - name: Install Node to use the Firebase CLI
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Check Snippets
       run: python scripts/checksnippets.py
-    # TODO(thatfiredev): remove this once github.com/firebase/quickstart-android/issues/1672 is fixed
-    - name: Remove Firebase Data Connect from CI
-      run: python scripts/ci_remove_fdc.py
     - name: Copy mock google_services.json
       run: ./copy_mock_google_services_json.sh
+    - name: Generate SDKs for the Data Connect quickstart
+      run: npx firebase dataconnect:compile
+      working-directory: ./dataconnect
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh
       if: github.event_name == 'pull_request'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,9 +29,6 @@ jobs:
       run: python scripts/checksnippets.py
     - name: Copy mock google_services.json
       run: ./copy_mock_google_services_json.sh
-    - name: Generate SDKs for the Data Connect quickstart
-      run: npx -y firebase-tools@latest dataconnect:compile
-      working-directory: ./dataconnect
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh
       if: github.event_name == 'pull_request'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Copy mock google_services.json
       run: ./copy_mock_google_services_json.sh
     - name: Generate SDKs for the Data Connect quickstart
-      run: npx firebase dataconnect:compile
+      run: npx -y firebase-tools@latest dataconnect:compile
       working-directory: ./dataconnect
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         }
+        exclude("**/build/generated/sources/**")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         }
-        exclude("**/build/generated/sources/**")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,8 @@ tasks.register<JavaExec>("ktlintCheck") {
         "--code-style=android_studio",
         "--reporter=plain",
         "--reporter=checkstyle,output=${outputFile}",
-        "**/*.kt"
+        "**/*.kt",
+        "!**/build/**"
     )
 
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")

--- a/dataconnect/app/build.gradle.kts
+++ b/dataconnect/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.compose.material.icons)
     implementation(libs.compose.navigation)
     implementation(libs.androidx.lifecycle.runtime.compose.android)
     implementation(libs.coil.compose)

--- a/dataconnect/app/build.gradle.kts
+++ b/dataconnect/app/build.gradle.kts
@@ -47,7 +47,9 @@ android {
         }
     }
     sourceSets.getByName("main") {
-        java.srcDirs("build/generated/sources")
+        kotlin.directories.add(
+            project.layout.projectDirectory.dir("build/generated/sources").toString()
+        )
     }
 }
 

--- a/dataconnect/app/build.gradle.kts
+++ b/dataconnect/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
         }
     }
     sourceSets.getByName("main") {
-        kotlin.directories.add("build/generated/sources")
+        java.directories.add("build/generated/sources")
     }
 }
 

--- a/dataconnect/app/build.gradle.kts
+++ b/dataconnect/app/build.gradle.kts
@@ -47,9 +47,7 @@ android {
         }
     }
     sourceSets.getByName("main") {
-        kotlin.directories.add(
-            project.layout.projectDirectory.dir("build/generated/sources").toString()
-        )
+        kotlin.directories.add("build/generated/sources")
     }
 }
 

--- a/dataconnect/app/build.gradle.kts
+++ b/dataconnect/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
         }
     }
     sourceSets.getByName("main") {
-        java.directories.add("build/generated/sources")
+        kotlin.directories.add("build/generated/sources")
     }
 }
 

--- a/dataconnect/build.gradle.kts
+++ b/dataconnect/build.gradle.kts
@@ -4,3 +4,22 @@ plugins {
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.compose.compiler) apply false
 }
+
+tasks {
+    register("clean", Delete::class) {
+        delete(rootProject.layout.buildDirectory)
+    }
+
+    register<Exec>("dataconnectCompile") {
+        workingDir = project.file("./dataconnect")
+        if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)) {
+            commandLine("npx.cmd", "-y", "firebase-tools@latest", "dataconnect:compile")
+        } else {
+            commandLine("npx", "-y", "firebase-tools@latest", "dataconnect:compile")
+        }
+    }
+
+    named("clean") {
+        finalizedBy("dataconnectCompile")
+    }
+}

--- a/dataconnect/build.gradle.kts
+++ b/dataconnect/build.gradle.kts
@@ -17,6 +17,7 @@ tasks {
         } else {
             commandLine("npx", "-y", "firebase-tools@latest", "dataconnect:compile")
         }
+        isIgnoreExitValue = true
     }
 
     named("clean") {

--- a/dataconnect/build.gradle.kts
+++ b/dataconnect/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
 }
 
 tasks {
-    register("clean", Delete::class) {
-        delete(rootProject.layout.buildDirectory)
-    }
-
     register<Exec>("dataconnectCompile") {
         workingDir = project.file("./dataconnect")
         if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)) {
@@ -20,7 +16,8 @@ tasks {
         isIgnoreExitValue = true
     }
 
-    named("clean") {
+    register("clean", Delete::class) {
+        delete(rootProject.layout.buildDirectory)
         finalizedBy("dataconnectCompile")
     }
 }

--- a/dataconnect/dataconnect/movie-connector/connector.yaml
+++ b/dataconnect/dataconnect/movie-connector/connector.yaml
@@ -10,4 +10,4 @@ generate:
     package: com.google.firebase.dataconnect.movies
     # Specify where to store the generated SDK
     # We're using the build/ directory so that generated code doesn't get checked into git
-    outputDir: ../../app/build/generated/sources/com/google/firebase/dataconnect/movies
+    outputDir: ../../app/build/generated/sources

--- a/dataconnect/dataconnect/movie-connector/queries.gql
+++ b/dataconnect/dataconnect/movie-connector/queries.gql
@@ -1,5 +1,5 @@
 # List subset of fields for movies
-query ListMovies($orderByRating: OrderDirection, $orderByReleaseYear: OrderDirection, $limit: Int) @auth(level: PUBLIC) {
+query ListMovies($orderByRating: OrderDirection, $orderByReleaseYear: OrderDirection, $limit: Int) @auth(level: PUBLIC, insecureReason: "Test Mode") {
   movies(
     orderBy: [
       { rating: $orderByRating },
@@ -19,7 +19,7 @@ query ListMovies($orderByRating: OrderDirection, $orderByReleaseYear: OrderDirec
 }
 
 # Get movie by id
-query GetMovieById($id: UUID!) @auth(level: PUBLIC) {
+query GetMovieById($id: UUID!) @auth(level: PUBLIC, insecureReason: "Test Mode") {
  movie(id: $id) {
     id
     title
@@ -58,7 +58,7 @@ query GetMovieById($id: UUID!) @auth(level: PUBLIC) {
  }
 
 # Get actor by id
-query GetActorById($id: UUID!) @auth(level: PUBLIC) {
+query GetActorById($id: UUID!) @auth(level: PUBLIC, insecureReason: "Test Mode") {
   actor(id: $id) {
     id
     name
@@ -130,7 +130,7 @@ query SearchAll(
   $minRating: Float!
   $maxRating: Float!
   $genre: String!
-) @auth(level: PUBLIC) {
+) @auth(level: PUBLIC, insecureReason: "Test Mode") {
   moviesMatchingTitle: movies(
     where: {
       _and: [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlin = "2.3.0"
 kotlinxSerializationCore = "1.9.0"
 lifecycle = "2.10.0"
 material = "1.13.0"
+materialIcons = "1.7.8"
 webkit = "1.14.0"
 
 [libraries]
@@ -58,6 +59,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
+compose-material-icons = { group = "androidx.compose.material", name = "material-icons-core",  version.ref = "materialIcons"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/scripts/ci_remove_fdc.py
+++ b/scripts/ci_remove_fdc.py
@@ -1,8 +1,0 @@
-# TODO(thatfiredev): remove this once github.com/firebase/quickstart-android/issues/1672 is fixed
-with open('settings.gradle.kts', 'r') as file:
-  filedata = file.read()
-
-filedata = filedata.replace('":dataconnect:app",', '')
-
-with open('settings.gradle.kts', 'w') as file:
-  file.write(filedata)


### PR DESCRIPTION
This should update our CI pipeline to install the Firebase CLI and run `firebase dataconnect:compile` to generate the SDKs for the Data Connect quickstart

Fixes #1672