### PR TITLE
refactor(ai): use gemini-3.1-flash-lite GA

### DIFF
--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/hybrid/HybridInferenceViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/hybrid/HybridInferenceViewModel.kt
@@ -41,7 +41,7 @@ class HybridInferenceViewModel : ViewModel() {
     val uiState: StateFlow<HybridInferenceUiState> = _uiState.asStateFlow()
 
     private val model = Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
-        modelName = "gemini-3.1-flash-lite-preview",
+        modelName = "gemini-3.1-flash-lite",
         onDeviceConfig = OnDeviceConfig(mode = InferenceMode.PREFER_ON_DEVICE)
     )
 

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/AudioSummarizationViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/AudioSummarizationViewModel.kt
@@ -28,7 +28,7 @@ class AudioSummarizationViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-3.1-flash-lite-preview"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat(
             listOf(

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/AudioTranslationViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/AudioTranslationViewModel.kt
@@ -20,7 +20,7 @@ class AudioTranslationViewModel : ChatViewModel() {
 
     init {
         val generativeModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
-            modelName = "gemini-2.5-flash"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat()
         

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/CourseRecommendationsViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/CourseRecommendationsViewModel.kt
@@ -23,7 +23,7 @@ class CourseRecommendationsViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.1-flash-lite",
             systemInstruction = content {
                 text(
                     "You are a chatbot for the county's performing and fine arts" +

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/DocumentComparisonViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/DocumentComparisonViewModel.kt
@@ -21,7 +21,7 @@ class DocumentComparisonViewModel : ChatViewModel() {
 
     init {
         val generativeModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
-            modelName = "gemini-2.5-flash"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat()
 

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/GoogleSearchGroundingViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/GoogleSearchGroundingViewModel.kt
@@ -23,7 +23,7 @@ class GoogleSearchGroundingViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.1-flash-lite",
             tools = listOf(Tool.googleSearch())
         )
         chat = generativeModel.startChat()

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/ImageBlogCreatorViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/ImageBlogCreatorViewModel.kt
@@ -22,7 +22,7 @@ class ImageBlogCreatorViewModel : ChatViewModel() {
 
     init {
         val generativeModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
-            modelName = "gemini-2.5-flash"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat()
 

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/TranslationViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/TranslationViewModel.kt
@@ -25,7 +25,7 @@ class TranslationViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-3.1-flash-lite-preview",
+            modelName = "gemini-3.1-flash-lite",
             systemInstruction = content {
                 text("Only output the translated text")
             }

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/TravelTipsViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/TravelTipsViewModel.kt
@@ -24,7 +24,7 @@ class TravelTipsViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.1-flash-lite",
             systemInstruction = content {
                 text(
                     "You are a Travel assistant. You will answer" +

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/VideoHashtagGeneratorViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/VideoHashtagGeneratorViewModel.kt
@@ -23,7 +23,7 @@ class VideoHashtagGeneratorViewModel : ChatViewModel() {
 
     init {
         val generativeModel = Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
-            modelName = "gemini-2.5-flash"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat()
 

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/VideoSummarizationViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/VideoSummarizationViewModel.kt
@@ -39,7 +39,7 @@ class VideoSummarizationViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-2.5-flash"
+            modelName = "gemini-3.1-flash-lite"
         )
         chat = generativeModel.startChat(chatHistory)
     }

--- a/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/WeatherChatViewModel.kt
+++ b/firebase-ai/app/src/main/java/com/google/firebase/quickstart/ai/feature/text/WeatherChatViewModel.kt
@@ -33,7 +33,7 @@ class WeatherChatViewModel : ChatViewModel() {
         val generativeModel = Firebase.ai(
             backend = GenerativeBackend.googleAI()
         ).generativeModel(
-            modelName = "gemini-2.5-flash",
+            modelName = "gemini-3.1-flash-lite",
             tools = listOf(
                 Tool.functionDeclarations(
                     listOf(


### PR DESCRIPTION
This should update our samples to use gemini-3.1-flash-lite GA.
It also upgrades some of the samples from `gemini-2.5-flash` to `gemini-3.1-flash-lite` because the 3.1 model can perform those tasks.