### PR TITLE
chore(*): remove obsolete flags from gradle.properties

### DIFF
--- a/analytics/app/src/androidTest/java/com/google/firebase/quickstart/analytics/MainActivityTest.java
+++ b/analytics/app/src/androidTest/java/com/google/firebase/quickstart/analytics/MainActivityTest.java
@@ -66,8 +66,8 @@ public class MainActivityTest {
         try{
             ViewInteraction appCompatTextView = onView(
                     allOf(withId(android.R.id.text1), withText(food),
-                            withParent(allOf(withId(R.id.select_dialog_listview),
-                                    withParent(withId(R.id.contentPanel)))),
+                            withParent(allOf(withId(androidx.appcompat.R.id.select_dialog_listview),
+                                    withParent(withId(androidx.appcompat.R.id.contentPanel)))),
                             isDisplayed()));
             appCompatTextView.perform(click());
         } catch (NoMatchingViewException e) {

--- a/appdistribution/app/src/androidTest/java/com/google/firebase/appdistributionquickstart/InstrumentedTest.java
+++ b/appdistribution/app/src/androidTest/java/com/google/firebase/appdistributionquickstart/InstrumentedTest.java
@@ -48,20 +48,20 @@ public class InstrumentedTest {
 
   @After
   public void tearDown() {
-      getView(R.id.collapse_button).perform(click());
+      getView(com.google.firebase.inappmessaging.display.R.id.collapse_button).perform(click());
   }
 
 
   @Test
   public void testFiamDisplaysOnForegroundCampaign() {
     reopen_app(); // reopen app to correctly trigger fetch
-    getView(R.id.modal_root).check(matches(isDisplayed()));
+    getView(com.google.firebase.inappmessaging.display.R.id.modal_root).check(matches(isDisplayed()));
   }
 
   @Test
   public void testFiamDisplaysContextualTriggerCampaign() {
     onView(withId(R.id.eventTriggerButton)).perform(click());
-    getView(R.id.modal_root).check(matches(isDisplayed()));
+    getView(com.google.firebase.inappmessaging.display.R.id.modal_root).check(matches(isDisplayed()));
   }
 
   private void reopen_app() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,3 @@ org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=6g -XX:ReservedCodeCacheSize=2g -
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
-
-## Play and Firebase moving to AndroidX
-android.useAndroidX=true
-android.nonTransitiveRClass=true
-android.nonFinalResIds=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ org.gradle.caching=true
 
 ## Play and Firebase moving to AndroidX
 android.useAndroidX=true
-android.nonTransitiveRClass=false
+android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ org.gradle.caching=true
 ## Play and Firebase moving to AndroidX
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
+android.nonFinalResIds=true

--- a/inappmessaging/app/src/androidTest/java/com/google/firebase/fiamquickstart/InstrumentedTest.java
+++ b/inappmessaging/app/src/androidTest/java/com/google/firebase/fiamquickstart/InstrumentedTest.java
@@ -26,8 +26,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 
-import com.google.firebase.fiamquickstart.R;
-
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -48,20 +46,20 @@ public class InstrumentedTest {
 
   @After
   public void tearDown() {
-      getView(R.id.collapse_button).perform(click());
+      getView(com.google.firebase.inappmessaging.display.R.id.collapse_button).perform(click());
   }
 
 
   @Test
   public void testFiamDisplaysOnForegroundCampaign() {
     reopen_app(); // reopen app to correctly trigger fetch
-    getView(R.id.modal_root).check(matches(isDisplayed()));
+    getView(com.google.firebase.inappmessaging.display.R.id.modal_root).check(matches(isDisplayed()));
   }
 
   @Test
   public void testFiamDisplaysContextualTriggerCampaign() {
     onView(withId(R.id.eventTriggerButton)).perform(click());
-    getView(R.id.modal_root).check(matches(isDisplayed()));
+    getView(com.google.firebase.inappmessaging.display.R.id.modal_root).check(matches(isDisplayed()));
   }
 
   private void reopen_app() {


### PR DESCRIPTION
All of these flags default to true in AGP 9.0 and are safe to remove.