### PR TITLE
ci: update actions - checkout@v5, setup-java@v5, setup-gradle@v6

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         distribution: 'zulu'
         java-version: 17
     - name: Install Node to use the Firebase CLI
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Copy mock google_services.json

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 17
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: 24
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v6
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Copy mock google_services.json

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number  || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+          persist-credentials: false
     - name: Set up JDK 17
       uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:


### PR DESCRIPTION
This PR should update our GitHub actions:
- `actions/checkout@v5` and `actions/setup-java@v5` both use Node 24 by default.
- `gradle/actions/setup-gradle` is the new action from Gradle, replacing `gradle/gradle-build-action`.