### PR TITLE
revert the AGP version pin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,17 +77,9 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
     }
 }
 
-// TODO(b/522845800): remove this once the bug with AGP 9.3.x and lint has been fixed
-fun isBuggyAGP(candidate: ModuleComponentIdentifier): Boolean {
-  // Skip 'com.android.application' and 'com.android.library' versions <= 9.3.1
-  return candidate.toString().lowercase().contains("com.android.") &&
-          candidate.version.replace(".", "").toInt() <= 931
-}
-
 tasks.withType<DependencyUpdatesTask> {
     rejectVersionIf {
-        (isNonStable(candidate) && notFromFirebase(candidate)) || isBlockListed(candidate) ||
-                isBuggyAGP(candidate)
+        (isNonStable(candidate) && notFromFirebase(candidate)) || isBlockListed(candidate)
     }
 }
 


### PR DESCRIPTION
We no longer need this now that [b/522845800](https://issuetracker.google.com/issues/522845800) has been fixed 